### PR TITLE
feat: 프런트엔드 공통 인프라 구성

### DIFF
--- a/.github/workflows/pr-review-autofix.yml
+++ b/.github/workflows/pr-review-autofix.yml
@@ -1,0 +1,86 @@
+name: PR 리뷰 자동 처리
+
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-fix-review:
+    # claude-code-action 봇이 만든 커밋으로 인한 재귀 실행 방지
+    if: github.actor != 'claude-code[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: 리뷰 코멘트 수집
+        id: review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr_number = context.payload.pull_request.number;
+            const branch = context.payload.pull_request.head.ref;
+
+            // 인라인 코멘트
+            const { data: comments } = await github.rest.pulls.listReviewComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number,
+            });
+
+            // 리뷰 요약 코멘트
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number,
+            });
+
+            const inlineComments = comments
+              .map(c => `[${c.path}:${c.line ?? c.original_line}]\n${c.body}`)
+              .join('\n---\n');
+
+            const reviewBodies = reviews
+              .filter(r => r.body && r.body.trim())
+              .map(r => `[리뷰 요약 by ${r.user.login}]\n${r.body}`)
+              .join('\n---\n');
+
+            const allComments = [inlineComments, reviewBodies].filter(Boolean).join('\n===\n');
+
+            core.setOutput('pr_number', pr_number);
+            core.setOutput('branch', branch);
+            core.setOutput('comments', allComments || '(리뷰 코멘트 없음)');
+
+      - name: Claude Code로 리뷰 분석 및 수정
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            PR #${{ steps.review.outputs.pr_number }} (`${{ steps.review.outputs.branch }}` 브랜치)에 다음 리뷰 코멘트가 달렸어.
+
+            === 리뷰 내용 ===
+            ${{ steps.review.outputs.comments }}
+            =================
+
+            각 코멘트를 분석해서:
+            - 타당한 지적이면 코드를 수정해줘
+            - 이미 반영됐거나 불필요한 내용이면 무시해
+
+            수정 후:
+            1. 프런트엔드 파일(front/) 수정했다면 반드시 `cd /Users/runner/work/IntervAI/IntervAI/front && npm ci && npm run typecheck` 실행해서 타입 에러 확인
+            2. 수정 사항이 있으면 `git add -A && git commit -m "fix: PR 리뷰 반영 (#${{ steps.review.outputs.pr_number }})" && git push` 실행
+            3. 수정 사항이 없으면 아무것도 하지 마
+
+            중요: 커밋 메시지에 반드시 `[skip ci]`를 붙이지 마 (리뷰 반영 기록이 필요함)

--- a/front/package.json
+++ b/front/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/front/src/app/App.tsx
+++ b/front/src/app/App.tsx
@@ -4,6 +4,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import axios from 'axios'
 import { useAuthStore } from '../features/auth/stores/authStore'
 import { setupHttpClient } from '../shared/api/httpClient'
+import { BASE_URL, API_PATHS } from '../shared/api/constants'
+import { ToastContainer } from '../shared/components/ui/Toast'
 import Router from './router'
 
 const queryClient = new QueryClient({
@@ -21,7 +23,7 @@ const queryClient = new QueryClient({
 const PUBLIC_PATHS = ['/login', '/register']
 
 const AppInitializer = () => {
-  const { accessToken, setAuth, clearAuth } = useAuthStore()
+  const { accessToken, setAuth, setAccessToken, clearAuth } = useAuthStore()
   const navigate = useNavigate()
   const location = useLocation()
   const initialized = useRef(false)
@@ -31,12 +33,7 @@ const AppInitializer = () => {
 
     setupHttpClient(
       () => getState().accessToken,
-      (token) => {
-        const state = getState()
-        if (state.userId !== null && state.nickname !== null) {
-          getState().setAuth(token, state.userId, state.nickname)
-        }
-      },
+      (token) => getState().setAccessToken(token),
       () => {
         getState().clearAuth()
         navigate('/login', { replace: true })
@@ -54,7 +51,7 @@ const AppInitializer = () => {
 
     axios
       .post<{ accessToken: string; id: number; nickname: string }>(
-        `${import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'}/api/auth/refresh`,
+        `${BASE_URL}${API_PATHS.auth.refresh}`,
         {},
         { withCredentials: true },
       )
@@ -68,7 +65,7 @@ const AppInitializer = () => {
           navigate('/login', { replace: true })
         }
       })
-  }, [accessToken, location.pathname, setAuth, clearAuth, navigate])
+  }, [accessToken, location.pathname, setAuth, setAccessToken, clearAuth, navigate])
 
   return null
 }
@@ -79,6 +76,7 @@ const App = () => {
       <BrowserRouter>
         <AppInitializer />
         <Router />
+        <ToastContainer />
       </BrowserRouter>
     </QueryClientProvider>
   )

--- a/front/src/app/App.tsx
+++ b/front/src/app/App.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from 'react'
+import { BrowserRouter, useNavigate, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import axios from 'axios'
+import { useAuthStore } from '../features/auth/stores/authStore'
+import { setupHttpClient } from '../shared/api/httpClient'
+import Router from './router'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 60_000,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+})
+
+const PUBLIC_PATHS = ['/login', '/register']
+
+const AppInitializer = () => {
+  const { accessToken, setAuth, clearAuth } = useAuthStore()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const initialized = useRef(false)
+
+  useEffect(() => {
+    const { getState } = useAuthStore
+
+    setupHttpClient(
+      () => getState().accessToken,
+      (token) => {
+        const state = getState()
+        if (state.userId !== null && state.nickname !== null) {
+          getState().setAuth(token, state.userId, state.nickname)
+        }
+      },
+      () => {
+        getState().clearAuth()
+        navigate('/login', { replace: true })
+      },
+    )
+  }, [navigate])
+
+  useEffect(() => {
+    if (initialized.current) return
+    initialized.current = true
+
+    if (accessToken) return
+
+    const isPublicPath = PUBLIC_PATHS.includes(location.pathname)
+
+    axios
+      .post<{ accessToken: string; id: number; nickname: string }>(
+        `${import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'}/api/auth/refresh`,
+        {},
+        { withCredentials: true },
+      )
+      .then((res) => {
+        const { accessToken: token, id, nickname } = res.data
+        setAuth(token, id, nickname)
+      })
+      .catch(() => {
+        clearAuth()
+        if (!isPublicPath) {
+          navigate('/login', { replace: true })
+        }
+      })
+  }, [accessToken, location.pathname, setAuth, clearAuth, navigate])
+
+  return null
+}
+
+const App = () => {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <AppInitializer />
+        <Router />
+      </BrowserRouter>
+    </QueryClientProvider>
+  )
+}
+
+export default App

--- a/front/src/app/App.tsx
+++ b/front/src/app/App.tsx
@@ -23,7 +23,8 @@ const queryClient = new QueryClient({
 const PUBLIC_PATHS = ['/login', '/register']
 
 const AppInitializer = () => {
-  const { accessToken, setAuth, setAccessToken, clearAuth } = useAuthStore()
+  const { accessToken, setAuth, clearAuth } = useAuthStore()
+  const setInitialized = useAuthStore((s) => s.setInitialized)
   const navigate = useNavigate()
   const location = useLocation()
   const initialized = useRef(false)
@@ -45,7 +46,10 @@ const AppInitializer = () => {
     if (initialized.current) return
     initialized.current = true
 
-    if (accessToken) return
+    if (accessToken) {
+      setInitialized(true)
+      return
+    }
 
     const isPublicPath = PUBLIC_PATHS.includes(location.pathname)
 
@@ -65,17 +69,22 @@ const AppInitializer = () => {
           navigate('/login', { replace: true })
         }
       })
-  }, [accessToken, location.pathname, setAuth, setAccessToken, clearAuth, navigate])
+      .finally(() => {
+        setInitialized(true)
+      })
+  }, [accessToken, location.pathname, setAuth, clearAuth, setInitialized, navigate])
 
   return null
 }
 
 const App = () => {
+  const isInitialized = useAuthStore((s) => s.isInitialized)
+
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <AppInitializer />
-        <Router />
+        {isInitialized ? <Router /> : null}
         <ToastContainer />
       </BrowserRouter>
     </QueryClientProvider>

--- a/front/src/app/router.tsx
+++ b/front/src/app/router.tsx
@@ -1,0 +1,28 @@
+import { Routes, Route } from 'react-router-dom'
+import PrivateRoute from '../shared/components/layout/PrivateRoute'
+import AppLayout from '../shared/components/layout/AppLayout'
+import LoginPage from '../features/auth/pages/LoginPage'
+import RegisterPage from '../features/auth/pages/RegisterPage'
+import DashboardPage from '../shared/pages/DashboardPage'
+import InterviewPage from '../features/interview/pages/InterviewPage'
+import NotFoundPage from '../shared/pages/NotFoundPage'
+
+const Router = () => {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+
+      <Route element={<PrivateRoute />}>
+        <Route element={<AppLayout />}>
+          <Route path="/" element={<DashboardPage />} />
+          <Route path="/interview" element={<InterviewPage />} />
+        </Route>
+      </Route>
+
+      <Route path="*" element={<NotFoundPage />} />
+    </Routes>
+  )
+}
+
+export default Router

--- a/front/src/features/auth/pages/LoginPage.tsx
+++ b/front/src/features/auth/pages/LoginPage.tsx
@@ -1,0 +1,9 @@
+const LoginPage = () => {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <p className="text-gray-500">로그인 페이지 (구현 예정)</p>
+    </div>
+  )
+}
+
+export default LoginPage

--- a/front/src/features/auth/pages/RegisterPage.tsx
+++ b/front/src/features/auth/pages/RegisterPage.tsx
@@ -1,0 +1,9 @@
+const RegisterPage = () => {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <p className="text-gray-500">회원가입 페이지 (구현 예정)</p>
+    </div>
+  )
+}
+
+export default RegisterPage

--- a/front/src/features/auth/stores/authStore.ts
+++ b/front/src/features/auth/stores/authStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand'
+
+interface AuthState {
+  accessToken: string | null
+  userId: number | null
+  nickname: string | null
+  setAuth: (accessToken: string, userId: number, nickname: string) => void
+  clearAuth: () => void
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  accessToken: null,
+  userId: null,
+  nickname: null,
+  setAuth: (accessToken, userId, nickname) =>
+    set({ accessToken, userId, nickname }),
+  clearAuth: () => set({ accessToken: null, userId: null, nickname: null }),
+}))

--- a/front/src/features/auth/stores/authStore.ts
+++ b/front/src/features/auth/stores/authStore.ts
@@ -5,6 +5,7 @@ interface AuthState {
   userId: number | null
   nickname: string | null
   setAuth: (accessToken: string, userId: number, nickname: string) => void
+  setAccessToken: (accessToken: string) => void
   clearAuth: () => void
 }
 
@@ -14,5 +15,6 @@ export const useAuthStore = create<AuthState>((set) => ({
   nickname: null,
   setAuth: (accessToken, userId, nickname) =>
     set({ accessToken, userId, nickname }),
+  setAccessToken: (accessToken) => set({ accessToken }),
   clearAuth: () => set({ accessToken: null, userId: null, nickname: null }),
 }))

--- a/front/src/features/auth/stores/authStore.ts
+++ b/front/src/features/auth/stores/authStore.ts
@@ -4,8 +4,10 @@ interface AuthState {
   accessToken: string | null
   userId: number | null
   nickname: string | null
+  isInitialized: boolean
   setAuth: (accessToken: string, userId: number, nickname: string) => void
   setAccessToken: (accessToken: string) => void
+  setInitialized: (isInitialized: boolean) => void
   clearAuth: () => void
 }
 
@@ -13,8 +15,10 @@ export const useAuthStore = create<AuthState>((set) => ({
   accessToken: null,
   userId: null,
   nickname: null,
+  isInitialized: false,
   setAuth: (accessToken, userId, nickname) =>
-    set({ accessToken, userId, nickname }),
+    set({ accessToken, userId, nickname, isInitialized: true }),
   setAccessToken: (accessToken) => set({ accessToken }),
-  clearAuth: () => set({ accessToken: null, userId: null, nickname: null }),
+  setInitialized: (isInitialized) => set({ isInitialized }),
+  clearAuth: () => set({ accessToken: null, userId: null, nickname: null, isInitialized: true }),
 }))

--- a/front/src/features/interview/pages/InterviewPage.tsx
+++ b/front/src/features/interview/pages/InterviewPage.tsx
@@ -1,0 +1,9 @@
+const InterviewPage = () => {
+  return (
+    <div className="p-8">
+      <p className="text-gray-500">면접 플로우 (구현 예정)</p>
+    </div>
+  )
+}
+
+export default InterviewPage

--- a/front/src/features/interview/stores/interviewStore.ts
+++ b/front/src/features/interview/stores/interviewStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+
+type InterviewPhase = 'setup' | 'generating' | 'chat' | 'finished'
+
+interface InterviewState {
+  interviewId: number | null
+  sessionId: number | null
+  phase: InterviewPhase
+  setInterview: (interviewId: number) => void
+  setSession: (sessionId: number) => void
+  setPhase: (phase: InterviewPhase) => void
+  resetInterview: () => void
+}
+
+export const useInterviewStore = create<InterviewState>((set) => ({
+  interviewId: null,
+  sessionId: null,
+  phase: 'setup',
+  setInterview: (interviewId) => set({ interviewId }),
+  setSession: (sessionId) => set({ sessionId }),
+  setPhase: (phase) => set({ phase }),
+  resetInterview: () =>
+    set({ interviewId: null, sessionId: null, phase: 'setup' }),
+}))

--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from './app/App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/front/src/shared/api/apiError.ts
+++ b/front/src/shared/api/apiError.ts
@@ -1,0 +1,29 @@
+import axios from 'axios'
+import type { ApiError } from '../types/api'
+
+export function extractApiError(error: unknown): ApiError {
+  if (axios.isAxiosError(error) && error.response?.data) {
+    return error.response.data as ApiError
+  }
+  return { code: 'UNKNOWN_ERROR', message: '알 수 없는 오류가 발생했습니다.' }
+}
+
+export const ERROR_MESSAGES: Record<string, string> = {
+  // 인증
+  INVALID_TOKEN: '인증이 만료되었습니다. 다시 로그인해주세요.',
+  EXPIRED_TOKEN: '인증이 만료되었습니다. 다시 로그인해주세요.',
+  LOGIN_FAILED: '닉네임 또는 비밀번호가 올바르지 않습니다.',
+  // 면접
+  INTERVIEW_NOT_FOUND: '면접을 찾을 수 없습니다.',
+  INTERVIEW_ACCESS_DENIED: '접근 권한이 없습니다.',
+  SESSION_NOT_FOUND: '면접 세션을 찾을 수 없습니다.',
+  SESSION_ALREADY_COMPLETED: '이미 종료된 면접입니다.',
+  ALL_QUESTIONS_ANSWERED: '모든 질문이 완료되었습니다.',
+  ANSWER_ALREADY_EXISTS: '이미 답변한 질문입니다.',
+  // 공통
+  UNKNOWN_ERROR: '알 수 없는 오류가 발생했습니다.',
+}
+
+export function getErrorMessage(code: string): string {
+  return ERROR_MESSAGES[code] ?? `오류가 발생했습니다. (${code})`
+}

--- a/front/src/shared/api/constants.ts
+++ b/front/src/shared/api/constants.ts
@@ -1,0 +1,7 @@
+export const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'
+
+export const API_PATHS = {
+  auth: {
+    refresh: '/api/auth/refresh',
+  },
+} as const

--- a/front/src/shared/api/httpClient.ts
+++ b/front/src/shared/api/httpClient.ts
@@ -1,7 +1,8 @@
 import axios from 'axios'
+import { BASE_URL, API_PATHS } from './constants'
 
 export const httpClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080',
+  baseURL: BASE_URL,
   withCredentials: true,
 })
 
@@ -36,7 +37,7 @@ httpClient.interceptors.response.use(
       originalRequest._retry = true
       try {
         const res = await axios.post(
-          `${import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080'}/api/auth/refresh`,
+          `${BASE_URL}${API_PATHS.auth.refresh}`,
           {},
           { withCredentials: true },
         )

--- a/front/src/shared/api/httpClient.ts
+++ b/front/src/shared/api/httpClient.ts
@@ -7,13 +7,16 @@ export const httpClient = axios.create({
 
 // accessToken을 런타임에 주입받기 위한 setter
 let accessTokenGetter: (() => string | null) | null = null
+let accessTokenSetter: ((token: string) => void) | null = null
 let onUnauthorized: (() => void) | null = null
 
 export function setupHttpClient(
   getToken: () => string | null,
+  setToken: (token: string) => void,
   handleUnauthorized: () => void,
 ) {
   accessTokenGetter = getToken
+  accessTokenSetter = setToken
   onUnauthorized = handleUnauthorized
 }
 
@@ -38,10 +41,8 @@ httpClient.interceptors.response.use(
           { withCredentials: true },
         )
         const newToken: string = res.data.accessToken
-        // 토큰 갱신 — setupHttpClient로 주입된 setter로 처리
-        if (accessTokenGetter) {
-          originalRequest.headers.Authorization = `Bearer ${newToken}`
-        }
+        accessTokenSetter?.(newToken)
+        originalRequest.headers.Authorization = `Bearer ${newToken}`
         return httpClient(originalRequest)
       } catch {
         onUnauthorized?.()

--- a/front/src/shared/api/httpClient.ts
+++ b/front/src/shared/api/httpClient.ts
@@ -41,7 +41,10 @@ httpClient.interceptors.response.use(
         refreshPromise = axios
           .post(`${BASE_URL}${API_PATHS.auth.refresh}`, {}, { withCredentials: true })
           .then((res) => {
-            const newToken: string = res.data.accessToken
+            const newToken = res.data?.accessToken
+            if (typeof newToken !== 'string') {
+              throw new Error('Invalid refresh response')
+            }
             accessTokenSetter?.(newToken)
             return newToken
           })

--- a/front/src/shared/api/httpClient.ts
+++ b/front/src/shared/api/httpClient.ts
@@ -10,6 +10,7 @@ export const httpClient = axios.create({
 let accessTokenGetter: (() => string | null) | null = null
 let accessTokenSetter: ((token: string) => void) | null = null
 let onUnauthorized: (() => void) | null = null
+let refreshPromise: Promise<string> | null = null
 
 export function setupHttpClient(
   getToken: () => string | null,
@@ -35,18 +36,27 @@ httpClient.interceptors.response.use(
     const originalRequest = error.config
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true
+
+      if (!refreshPromise) {
+        refreshPromise = axios
+          .post(`${BASE_URL}${API_PATHS.auth.refresh}`, {}, { withCredentials: true })
+          .then((res) => {
+            const newToken: string = res.data.accessToken
+            accessTokenSetter?.(newToken)
+            return newToken
+          })
+          .finally(() => {
+            refreshPromise = null
+          })
+      }
+
       try {
-        const res = await axios.post(
-          `${BASE_URL}${API_PATHS.auth.refresh}`,
-          {},
-          { withCredentials: true },
-        )
-        const newToken: string = res.data.accessToken
-        accessTokenSetter?.(newToken)
+        const newToken = await refreshPromise
         originalRequest.headers.Authorization = `Bearer ${newToken}`
         return httpClient(originalRequest)
-      } catch {
+      } catch (err) {
         onUnauthorized?.()
+        return Promise.reject(err)
       }
     }
     return Promise.reject(error)

--- a/front/src/shared/components/layout/AppLayout.tsx
+++ b/front/src/shared/components/layout/AppLayout.tsx
@@ -1,0 +1,64 @@
+import { NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../../../features/auth/stores/authStore'
+
+const navItems = [
+  { label: '대시보드', to: '/' },
+  { label: '새 면접', to: '/interview' },
+  { label: '히스토리', to: '/history' },
+]
+
+const AppLayout = () => {
+  const nickname = useAuthStore((s) => s.nickname)
+  const clearAuth = useAuthStore((s) => s.clearAuth)
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    clearAuth()
+    navigate('/login', { replace: true })
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <aside className="w-60 flex-shrink-0 bg-gray-900 text-white flex flex-col">
+        <div className="px-6 py-5 text-xl font-bold tracking-tight">
+          IntervAI
+        </div>
+
+        <nav className="flex-1 px-3 space-y-1">
+          {navItems.map(({ label, to }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={to === '/'}
+              className={({ isActive }) =>
+                `block px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                  isActive
+                    ? 'bg-gray-700 text-white'
+                    : 'text-gray-400 hover:bg-gray-800 hover:text-white'
+                }`
+              }
+            >
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <div className="px-4 py-4 border-t border-gray-700 flex items-center justify-between gap-2">
+          <span className="text-sm text-gray-300 truncate">{nickname ?? ''}</span>
+          <button
+            onClick={handleLogout}
+            className="text-xs text-gray-400 hover:text-white px-2 py-1 rounded hover:bg-gray-800 transition-colors flex-shrink-0"
+          >
+            로그아웃
+          </button>
+        </div>
+      </aside>
+
+      <main className="flex-1 bg-gray-50 overflow-auto">
+        <Outlet />
+      </main>
+    </div>
+  )
+}
+
+export default AppLayout

--- a/front/src/shared/components/layout/PrivateRoute.tsx
+++ b/front/src/shared/components/layout/PrivateRoute.tsx
@@ -1,0 +1,14 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuthStore } from '../../../features/auth/stores/authStore'
+
+const PrivateRoute = () => {
+  const accessToken = useAuthStore((s) => s.accessToken)
+
+  if (!accessToken) {
+    return <Navigate to="/login" replace />
+  }
+
+  return <Outlet />
+}
+
+export default PrivateRoute

--- a/front/src/shared/components/ui/ErrorBoundary.tsx
+++ b/front/src/shared/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component } from 'react'
+import type { ReactNode, ErrorInfo } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info)
+  }
+
+  handleReload = () => {
+    window.location.reload()
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+          <p className="text-lg text-gray-700">예기치 못한 오류가 발생했습니다.</p>
+          <button
+            onClick={this.handleReload}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            새로고침
+          </button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/front/src/shared/components/ui/Toast.tsx
+++ b/front/src/shared/components/ui/Toast.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { create } from 'zustand'
 
 type ToastType = 'error' | 'success' | 'info'
 
@@ -8,27 +8,30 @@ interface ToastItem {
   type: ToastType
 }
 
+interface ToastState {
+  toasts: ToastItem[]
+  toast: (message: string, type?: ToastType) => void
+  removeToast: (id: number) => void
+}
+
 let toastIdCounter = 0
 
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  toast: (message, type = 'info') => {
+    const id = ++toastIdCounter
+    set((state) => ({ toasts: [...state.toasts, { id, message, type }] }))
+    setTimeout(() => {
+      set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }))
+    }, 3000)
+  },
+  removeToast: (id) =>
+    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
+}))
+
 export const useToast = () => {
-  const [toasts, setToasts] = useState<ToastItem[]>([])
-
-  const removeToast = useCallback((id: number) => {
-    setToasts((prev) => prev.filter((t) => t.id !== id))
-  }, [])
-
-  const toast = useCallback(
-    (message: string, type: ToastType = 'info') => {
-      const id = ++toastIdCounter
-      setToasts((prev) => [...prev, { id, message, type }])
-      setTimeout(() => {
-        setToasts((prev) => prev.filter((t) => t.id !== id))
-      }, 3000)
-    },
-    [],
-  )
-
-  return { toast, toasts, removeToast }
+  const { toast } = useToastStore()
+  return { toast }
 }
 
 const typeStyles: Record<ToastType, string> = {
@@ -37,47 +40,25 @@ const typeStyles: Record<ToastType, string> = {
   info: 'bg-gray-800 text-white',
 }
 
-interface ToastContainerProps {
-  toasts: ToastItem[]
-  removeToast: (id: number) => void
-}
+export const ToastContainer = () => {
+  const { toasts, removeToast } = useToastStore()
 
-const ToastItemComponent = ({
-  item,
-  onRemove,
-}: {
-  item: ToastItem
-  onRemove: () => void
-}) => {
-  useEffect(() => {
-    return () => {}
-  }, [])
-
-  return (
-    <div
-      className={`flex items-center justify-between gap-3 px-4 py-3 rounded-lg shadow-lg min-w-64 max-w-sm ${typeStyles[item.type]}`}
-    >
-      <span className="text-sm">{item.message}</span>
-      <button
-        onClick={onRemove}
-        className="text-white/80 hover:text-white flex-shrink-0"
-        aria-label="닫기"
-      >
-        x
-      </button>
-    </div>
-  )
-}
-
-export const ToastContainer = ({ toasts, removeToast }: ToastContainerProps) => {
   return (
     <div className="fixed bottom-4 right-4 flex flex-col gap-2 z-50">
       {toasts.map((item) => (
-        <ToastItemComponent
+        <div
           key={item.id}
-          item={item}
-          onRemove={() => removeToast(item.id)}
-        />
+          className={`flex items-center justify-between gap-3 px-4 py-3 rounded-lg shadow-lg min-w-64 max-w-sm ${typeStyles[item.type]}`}
+        >
+          <span className="text-sm">{item.message}</span>
+          <button
+            onClick={() => removeToast(item.id)}
+            className="text-white/80 hover:text-white flex-shrink-0"
+            aria-label="닫기"
+          >
+            ✕
+          </button>
+        </div>
       ))}
     </div>
   )

--- a/front/src/shared/components/ui/Toast.tsx
+++ b/front/src/shared/components/ui/Toast.tsx
@@ -1,0 +1,84 @@
+import { useState, useCallback, useEffect } from 'react'
+
+type ToastType = 'error' | 'success' | 'info'
+
+interface ToastItem {
+  id: number
+  message: string
+  type: ToastType
+}
+
+let toastIdCounter = 0
+
+export const useToast = () => {
+  const [toasts, setToasts] = useState<ToastItem[]>([])
+
+  const removeToast = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  const toast = useCallback(
+    (message: string, type: ToastType = 'info') => {
+      const id = ++toastIdCounter
+      setToasts((prev) => [...prev, { id, message, type }])
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => t.id !== id))
+      }, 3000)
+    },
+    [],
+  )
+
+  return { toast, toasts, removeToast }
+}
+
+const typeStyles: Record<ToastType, string> = {
+  error: 'bg-red-500 text-white',
+  success: 'bg-green-500 text-white',
+  info: 'bg-gray-800 text-white',
+}
+
+interface ToastContainerProps {
+  toasts: ToastItem[]
+  removeToast: (id: number) => void
+}
+
+const ToastItemComponent = ({
+  item,
+  onRemove,
+}: {
+  item: ToastItem
+  onRemove: () => void
+}) => {
+  useEffect(() => {
+    return () => {}
+  }, [])
+
+  return (
+    <div
+      className={`flex items-center justify-between gap-3 px-4 py-3 rounded-lg shadow-lg min-w-64 max-w-sm ${typeStyles[item.type]}`}
+    >
+      <span className="text-sm">{item.message}</span>
+      <button
+        onClick={onRemove}
+        className="text-white/80 hover:text-white flex-shrink-0"
+        aria-label="닫기"
+      >
+        x
+      </button>
+    </div>
+  )
+}
+
+export const ToastContainer = ({ toasts, removeToast }: ToastContainerProps) => {
+  return (
+    <div className="fixed bottom-4 right-4 flex flex-col gap-2 z-50">
+      {toasts.map((item) => (
+        <ToastItemComponent
+          key={item.id}
+          item={item}
+          onRemove={() => removeToast(item.id)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/front/src/shared/pages/DashboardPage.tsx
+++ b/front/src/shared/pages/DashboardPage.tsx
@@ -1,0 +1,9 @@
+const DashboardPage = () => {
+  return (
+    <div className="p-8">
+      <p className="text-gray-500">대시보드 (구현 예정)</p>
+    </div>
+  )
+}
+
+export default DashboardPage

--- a/front/src/shared/pages/ErrorPage.tsx
+++ b/front/src/shared/pages/ErrorPage.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom'
+
+interface ErrorPageProps {
+  message?: string
+}
+
+const ErrorPage = ({ message = '오류가 발생했습니다.' }: ErrorPageProps) => {
+  const navigate = useNavigate()
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <p className="text-lg text-gray-700">{message}</p>
+      <div className="flex gap-3">
+        <button
+          onClick={() => window.location.reload()}
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          다시 시도
+        </button>
+        <button
+          onClick={() => navigate('/', { replace: true })}
+          className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors"
+        >
+          홈으로
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default ErrorPage

--- a/front/src/shared/pages/NotFoundPage.tsx
+++ b/front/src/shared/pages/NotFoundPage.tsx
@@ -1,0 +1,20 @@
+import { useNavigate } from 'react-router-dom'
+
+const NotFoundPage = () => {
+  const navigate = useNavigate()
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <h1 className="text-4xl font-bold text-gray-800">404</h1>
+      <p className="text-lg text-gray-600">페이지를 찾을 수 없습니다.</p>
+      <button
+        onClick={() => navigate('/', { replace: true })}
+        className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+      >
+        대시보드로 돌아가기
+      </button>
+    </div>
+  )
+}
+
+export default NotFoundPage

--- a/front/tsconfig.app.json
+++ b/front/tsconfig.app.json
@@ -20,6 +20,7 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },


### PR DESCRIPTION
## Summary

- Zustand 스토어 추가: `authStore`(accessToken 메모리 전용), `interviewStore`(phase 관리)
- httpClient silent refresh 버그 수정: refresh 성공 시 authStore에 새 토큰 저장
- API 에러 처리 유틸: `extractApiError`, `getErrorMessage` (에러 코드 → 한국어 메시지)
- 공통 레이아웃: `AppLayout`(왼쪽 사이드바), `PrivateRoute`(비인증 리다이렉트)
- 에러 UI: `Toast`/`useToast`, `ErrorBoundary`, `NotFoundPage`, `ErrorPage`
- 앱 진입점: `App.tsx`(QC Provider + 초기화), `router.tsx`(라우트 정의)

## Test plan

- [ ] `npm run typecheck` 통과 확인
- [ ] `npm run dev` 로 앱 실행 후 라우팅 동작 확인
- [ ] 비인증 상태에서 `/` 접근 시 `/login` 리다이렉트 확인
- [ ] 존재하지 않는 경로 접근 시 `NotFoundPage` 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)