### PR TITLE
[FE] 로그인/회원가입 페이지 구현

### DIFF
--- a/front/CLAUDE.md
+++ b/front/CLAUDE.md
@@ -19,7 +19,6 @@ TanStack Query v5 · Zustand v5 · axios · react-router-dom v7 · react-hook-fo
 | 기능 | `fe/feat/{도메인}` | `fe/feat/auth` |
 | 버그 | `fe/fix/{도메인}` | `fe/fix/chat` |
 | 리팩터링 | `fe/refactor/{도메인}` | `fe/refactor/profile` |
-
 ---
 
 ## 개발 명령어
@@ -46,7 +45,12 @@ npm run typecheck  # tsc --noEmit
 
 ```
 [1] 요구사항(docs) 체크 -> 디자인(Stitch mcp) + 백엔드 현황(src/) 체크 -> dev-planner로 PLAN.md
-[2] plan-executor → 브랜치 이동 -> frontend-developer → 구현
+[2] plan-executor → 브랜치 이동(fe/feat/{도메인})
+[3] frontend-developer → 구현 -> 코드 리뷰(/codex:review --background 사용)
+[4] 논리적 단위로 커밋 분리 → git push
+[5] gh pr create → PR 생성 (base: main)
+[6] PR 리뷰 확인 → 수정 필요 여부 판단 (필요 없으면 코멘트 전부 resolve 처리) 
+[7] 수정할 경우 [3], [4] 다시 진행 → push 및 해결된 코멘트 resolve
 ```
 
 **dev-planner 호출 시 전달:**
@@ -54,3 +58,6 @@ npm run typecheck  # tsc --noEmit
 - Stitch 화면 ID
 - 백엔드 경로: `src/main/java/wlsh/project/intervai/{도메인}/`
 - 브랜치: `fe/feat/{도메인}`
+
+**참고자료**
+./GITHUB.md : 프런트 브랜치 전략, PR 전략

--- a/front/CLAUDE.md
+++ b/front/CLAUDE.md
@@ -44,13 +44,14 @@ npm run typecheck  # tsc --noEmit
 ## 기능 개발 워크플로우
 
 ```
-[1] 요구사항(docs) 체크 -> 디자인(Stitch mcp) + 백엔드 현황(src/) 체크 -> dev-planner로 PLAN.md
-[2] plan-executor → 브랜치 이동(fe/feat/{도메인})
-[3] frontend-developer → 구현 -> 코드 리뷰(/codex:review --background 사용)
-[4] 논리적 단위로 커밋 분리 → git push
-[5] gh pr create → PR 생성 (base: main)
-[6] PR 리뷰 확인 → 수정 필요 여부 판단 (필요 없으면 코멘트 전부 resolve 처리) 
-[7] 수정할 경우 [3], [4] 다시 진행 → push 및 해결된 코멘트 resolve
+[1] 요구사항(docs) 체크 -> 디자인(Stitch mcp) 조회
+[2] docs/api.md 조회 -> dev-planner로 PLAN.md
+[3] plan-executor → 브랜치 이동(fe/feat/{도메인})
+[4] frontend-developer → 구현 -> 코드 리뷰(/codex:review --background 사용)
+[5] 논리적 단위로 커밋 분리 → git push
+[6] gh pr create → PR 생성 (base: main)
+[7] PR 리뷰 확인 → 수정 필요 여부 판단 (필요 없으면 코멘트 전부 resolve 처리) 
+[8] 수정할 경우 [3], [4] 다시 진행 → push 및 해결된 코멘트 resolve
 ```
 
 **dev-planner 호출 시 전달:**

--- a/front/GITHUB.md
+++ b/front/GITHUB.md
@@ -1,0 +1,13 @@
+**브랜치 규칙 (필수)**
+- 프런트 작업 전 반드시 현재 브랜치 확인
+- `fe/` 접두사 브랜치인지 검증 (`feat/`는 백엔드 전용)
+
+
+**PR 리뷰 확인 명령어:**
+```bash
+gh api repos/wlsh44/IntervAI/pulls/{pr_number}/comments --jq '.[] | "FILE: \(.path)\nLINE: \(.line)\nBODY:\n\(.body)\n---"'
+gh api repos/wlsh44/IntervAI/pulls/{pr_number}/reviews
+```
+
+**PR 리뷰**
+- PR Title의 경우 백엔드와 구분할 수 있게 `[FE] ` 를 접두사로 붙임 

--- a/front/index.html
+++ b/front/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>front</title>
+    <title>IntervAI</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@tanstack/react-query": "^5.96.2",
         "axios": "^1.14.0",
+        "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hook-form": "^7.72.1",
@@ -2940,6 +2941,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/front/package.json
+++ b/front/package.json
@@ -14,6 +14,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@tanstack/react-query": "^5.96.2",
     "axios": "^1.14.0",
+    "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hook-form": "^7.72.1",

--- a/front/src/features/auth/api/authApi.ts
+++ b/front/src/features/auth/api/authApi.ts
@@ -1,4 +1,11 @@
-import { httpClient } from '../../../shared/api/httpClient'
+import axios from 'axios'
+import { BASE_URL } from '../../../shared/api/constants'
+
+// 인증 API는 refresh 인터셉터를 우회하기 위해 별도 axios 인스턴스 사용
+const authClient = axios.create({
+  baseURL: BASE_URL,
+  withCredentials: true,
+})
 
 interface AuthRequest {
   nickname: string
@@ -12,11 +19,11 @@ interface AuthResponse {
 }
 
 export async function login(body: AuthRequest): Promise<AuthResponse> {
-  const res = await httpClient.post<AuthResponse>('/api/users/login', body)
+  const res = await authClient.post<AuthResponse>('/api/users/login', body)
   return res.data
 }
 
 export async function signUp(body: AuthRequest): Promise<AuthResponse> {
-  const res = await httpClient.post<AuthResponse>('/api/users/sign-up', body)
+  const res = await authClient.post<AuthResponse>('/api/users/sign-up', body)
   return res.data
 }

--- a/front/src/features/auth/api/authApi.ts
+++ b/front/src/features/auth/api/authApi.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { BASE_URL } from '../../../shared/api/constants'
+import { BASE_URL, API_PATHS } from '../../../shared/api/constants'
 
 // 인증 API는 refresh 인터셉터를 우회하기 위해 별도 axios 인스턴스 사용
 const authClient = axios.create({
@@ -19,11 +19,11 @@ interface AuthResponse {
 }
 
 export async function login(body: AuthRequest): Promise<AuthResponse> {
-  const res = await authClient.post<AuthResponse>('/api/users/login', body)
+  const res = await authClient.post<AuthResponse>(API_PATHS.users.login, body)
   return res.data
 }
 
 export async function signUp(body: AuthRequest): Promise<AuthResponse> {
-  const res = await authClient.post<AuthResponse>('/api/users/sign-up', body)
+  const res = await authClient.post<AuthResponse>(API_PATHS.users.signUp, body)
   return res.data
 }

--- a/front/src/features/auth/api/authApi.ts
+++ b/front/src/features/auth/api/authApi.ts
@@ -1,0 +1,22 @@
+import { httpClient } from '../../../shared/api/httpClient'
+
+interface AuthRequest {
+  nickname: string
+  password: string
+}
+
+interface AuthResponse {
+  id: number
+  nickname: string
+  accessToken: string
+}
+
+export async function login(body: AuthRequest): Promise<AuthResponse> {
+  const res = await httpClient.post<AuthResponse>('/api/users/login', body)
+  return res.data
+}
+
+export async function signUp(body: AuthRequest): Promise<AuthResponse> {
+  const res = await httpClient.post<AuthResponse>('/api/users/sign-up', body)
+  return res.data
+}

--- a/front/src/features/auth/components/AuthLayout.tsx
+++ b/front/src/features/auth/components/AuthLayout.tsx
@@ -1,24 +1,66 @@
 interface AuthLayoutProps {
   title: string
+  subtitle: string
+  footer: React.ReactNode
   children: React.ReactNode
 }
 
-const AuthLayout = ({ title, children }: AuthLayoutProps) => {
+const AuthLayout = ({ title, subtitle, footer, children }: AuthLayoutProps) => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-auth-bg">
-      <div className="w-full max-w-md px-6">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold tracking-tight text-white font-[Manrope]">
-            Interv<span className="bg-gradient-to-r from-auth-primary to-auth-secondary bg-clip-text text-transparent">AI</span>
-          </h1>
-          <p className="mt-2 text-sm text-auth-muted">AI 면접 연습 서비스</p>
+    <div
+      className="min-h-screen flex flex-col items-center justify-center bg-auth-bg px-6 py-12"
+      style={{ fontFamily: 'Inter, sans-serif' }}
+    >
+      {/* 배경 그라데이션 블러 */}
+      <div className="pointer-events-none fixed inset-0 overflow-hidden">
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[700px] h-[350px] rounded-full bg-auth-primary opacity-[0.05] blur-[120px]" />
+        <div className="absolute bottom-0 right-1/4 w-[400px] h-[300px] rounded-full bg-auth-secondary opacity-[0.04] blur-[100px]" />
+      </div>
+
+      {/* 로고 */}
+      <div className="text-center mb-8">
+        <h1 className="text-4xl font-bold" style={{ letterSpacing: '-0.02em' }}>
+          <span
+            className="bg-clip-text text-transparent"
+            style={{ backgroundImage: 'linear-gradient(135deg, #4648d4 0%, #6b38d4 100%)' }}
+          >
+            IntervAI
+          </span>
+        </h1>
+        <p className="mt-1.5 text-xs font-semibold tracking-[0.12em] text-auth-muted uppercase">
+          The Intelligent Career Curator
+        </p>
+      </div>
+
+      {/* 카드 */}
+      <div
+        className="relative w-full max-w-md rounded-2xl p-8"
+        style={{
+          background: 'rgba(250, 248, 255, 0.8)',
+          backdropFilter: 'blur(24px)',
+          boxShadow: '0 20px 40px -12px rgba(70, 72, 212, 0.1), 0 1px 3px rgba(70, 72, 212, 0.06)',
+          border: '1px solid rgba(199, 196, 215, 0.3)',
+        }}
+      >
+        {/* 카드 헤더 */}
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold text-auth-text">{title}</h2>
+          <p className="mt-1 text-sm text-auth-muted">{subtitle}</p>
         </div>
 
-        <div className="bg-auth-card rounded-2xl p-8 shadow-[0_48px_96px_rgba(14,21,48,0.06)]">
-          <h2 className="text-xl font-semibold text-auth-text mb-6">{title}</h2>
-          {children}
+        {/* 폼 */}
+        {children}
+
+        {/* 카드 하단 링크 */}
+        <div className="mt-6 text-center text-sm text-auth-muted">
+          {footer}
         </div>
       </div>
+
+      {/* 페이지 하단 저작권 */}
+      <p className="mt-8 text-xs text-auth-muted/60">
+        © 2024 IntervAI. All rights reserved.
+      </p>
     </div>
   )
 }

--- a/front/src/features/auth/components/AuthLayout.tsx
+++ b/front/src/features/auth/components/AuthLayout.tsx
@@ -1,0 +1,26 @@
+interface AuthLayoutProps {
+  title: string
+  children: React.ReactNode
+}
+
+const AuthLayout = ({ title, children }: AuthLayoutProps) => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#060e20]">
+      <div className="w-full max-w-md px-6">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-white font-[Manrope]">
+            Interv<span className="bg-gradient-to-r from-[#85adff] to-[#ac8aff] bg-clip-text text-transparent">AI</span>
+          </h1>
+          <p className="mt-2 text-sm text-[#a3aac4]">AI 면접 연습 서비스</p>
+        </div>
+
+        <div className="bg-[#0f1930] rounded-2xl p-8 shadow-[0_48px_96px_rgba(14,21,48,0.06)]">
+          <h2 className="text-xl font-semibold text-[#dee5ff] mb-6">{title}</h2>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default AuthLayout

--- a/front/src/features/auth/components/AuthLayout.tsx
+++ b/front/src/features/auth/components/AuthLayout.tsx
@@ -5,17 +5,17 @@ interface AuthLayoutProps {
 
 const AuthLayout = ({ title, children }: AuthLayoutProps) => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#060e20]">
+    <div className="min-h-screen flex items-center justify-center bg-auth-bg">
       <div className="w-full max-w-md px-6">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold tracking-tight text-white font-[Manrope]">
-            Interv<span className="bg-gradient-to-r from-[#85adff] to-[#ac8aff] bg-clip-text text-transparent">AI</span>
+            Interv<span className="bg-gradient-to-r from-auth-primary to-auth-secondary bg-clip-text text-transparent">AI</span>
           </h1>
-          <p className="mt-2 text-sm text-[#a3aac4]">AI 면접 연습 서비스</p>
+          <p className="mt-2 text-sm text-auth-muted">AI 면접 연습 서비스</p>
         </div>
 
-        <div className="bg-[#0f1930] rounded-2xl p-8 shadow-[0_48px_96px_rgba(14,21,48,0.06)]">
-          <h2 className="text-xl font-semibold text-[#dee5ff] mb-6">{title}</h2>
+        <div className="bg-auth-card rounded-2xl p-8 shadow-[0_48px_96px_rgba(14,21,48,0.06)]">
+          <h2 className="text-xl font-semibold text-auth-text mb-6">{title}</h2>
           {children}
         </div>
       </div>

--- a/front/src/features/auth/components/NicknameInput.tsx
+++ b/front/src/features/auth/components/NicknameInput.tsx
@@ -1,0 +1,39 @@
+import { User } from 'lucide-react'
+import type { UseFormRegisterReturn, FieldError } from 'react-hook-form'
+
+interface NicknameInputProps {
+  id: string
+  label: string
+  registration: UseFormRegisterReturn
+  error?: FieldError
+  placeholder?: string
+  disabled?: boolean
+  hint?: string
+}
+
+const NicknameInput = ({ id, label, registration, error, placeholder, disabled, hint }: NicknameInputProps) => {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-auth-text mb-1.5">
+        {label}
+        {hint && <span className="text-auth-muted font-normal ml-1">{hint}</span>}
+      </label>
+      <div className="relative">
+        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-auth-muted">
+          <User size={16} />
+        </span>
+        <input
+          id={id}
+          {...registration}
+          type="text"
+          placeholder={placeholder}
+          disabled={disabled}
+          className="w-full bg-auth-input text-auth-text placeholder-auth-outline rounded-xl pl-9 pr-4 py-3 text-sm outline-none transition-all disabled:opacity-50 focus:bg-white focus:shadow-[0_0_0_3px_rgba(70,72,212,0.12)]"
+        />
+      </div>
+      {error && <p className="mt-1.5 text-xs text-auth-error">{error.message}</p>}
+    </div>
+  )
+}
+
+export default NicknameInput

--- a/front/src/features/auth/components/PasswordInput.tsx
+++ b/front/src/features/auth/components/PasswordInput.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Eye, EyeOff } from 'lucide-react'
+import { Eye, EyeOff, Lock } from 'lucide-react'
 import type { UseFormRegisterReturn, FieldError } from 'react-hook-form'
 
 interface PasswordInputProps {
@@ -17,18 +17,21 @@ const PasswordInput = ({ id, label, registration, error, placeholder, disabled, 
 
   return (
     <div>
-      <label htmlFor={id} className="block text-sm text-auth-muted mb-1.5">
+      <label htmlFor={id} className="block text-sm font-medium text-auth-text mb-1.5">
         {label}
-        {hint && <span className="text-auth-outline ml-1">{hint}</span>}
+        {hint && <span className="text-auth-muted font-normal ml-1">{hint}</span>}
       </label>
       <div className="relative">
+        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-auth-muted">
+          <Lock size={16} />
+        </span>
         <input
           id={id}
           {...registration}
           type={show ? 'text' : 'password'}
           placeholder={placeholder}
           disabled={disabled}
-          className="w-full bg-auth-input text-auth-text placeholder-auth-outline rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-auth-outline/20 focus:border-auth-primary/50 transition-colors disabled:opacity-50"
+          className="w-full bg-auth-input text-auth-text placeholder-auth-outline rounded-xl pl-9 pr-11 py-3 text-sm outline-none transition-all disabled:opacity-50 focus:bg-white focus:shadow-[0_0_0_3px_rgba(70,72,212,0.12)]"
         />
         <button
           type="button"

--- a/front/src/features/auth/components/PasswordInput.tsx
+++ b/front/src/features/auth/components/PasswordInput.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
+import type { UseFormRegisterReturn, FieldError } from 'react-hook-form'
+
+interface PasswordInputProps {
+  id: string
+  label: string
+  registration: UseFormRegisterReturn
+  error?: FieldError
+  placeholder?: string
+  disabled?: boolean
+  hint?: string
+}
+
+const PasswordInput = ({ id, label, registration, error, placeholder, disabled, hint }: PasswordInputProps) => {
+  const [show, setShow] = useState(false)
+
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm text-auth-muted mb-1.5">
+        {label}
+        {hint && <span className="text-auth-outline ml-1">{hint}</span>}
+      </label>
+      <div className="relative">
+        <input
+          id={id}
+          {...registration}
+          type={show ? 'text' : 'password'}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="w-full bg-auth-input text-auth-text placeholder-auth-outline rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-auth-outline/20 focus:border-auth-primary/50 transition-colors disabled:opacity-50"
+        />
+        <button
+          type="button"
+          onClick={() => setShow((v) => !v)}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-auth-muted hover:text-auth-text transition-colors"
+          aria-label={show ? '비밀번호 숨기기' : '비밀번호 보기'}
+        >
+          {show ? <EyeOff size={18} /> : <Eye size={18} />}
+        </button>
+      </div>
+      {error && <p className="mt-1.5 text-xs text-auth-error">{error.message}</p>}
+    </div>
+  )
+}
+
+export default PasswordInput

--- a/front/src/features/auth/hooks/useAuthMutation.ts
+++ b/front/src/features/auth/hooks/useAuthMutation.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { useAuthStore } from '../stores/authStore'
+import { extractApiError, getErrorMessage } from '../../../shared/api/apiError'
+import { useToast } from '../../../shared/components/ui/Toast'
+import type { login } from '../api/authApi'
+
+type AuthMutationFn = typeof login
+
+export function useAuthMutation(mutationFn: AuthMutationFn) {
+  const navigate = useNavigate()
+  const setAuth = useAuthStore((s) => s.setAuth)
+  const { toast } = useToast()
+
+  return useMutation({
+    mutationFn,
+    onSuccess: (data) => {
+      setAuth(data.accessToken, data.id, data.nickname)
+      navigate('/')
+    },
+    onError: (error) => {
+      const { code } = extractApiError(error)
+      toast(getErrorMessage(code), 'error')
+    },
+  })
+}

--- a/front/src/features/auth/hooks/useAuthMutation.ts
+++ b/front/src/features/auth/hooks/useAuthMutation.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useAuthStore } from '../stores/authStore'
 import { extractApiError, getErrorMessage } from '../../../shared/api/apiError'
 import { useToast } from '../../../shared/components/ui/Toast'
@@ -9,6 +9,7 @@ type AuthMutationFn = typeof login
 
 export function useAuthMutation(mutationFn: AuthMutationFn) {
   const navigate = useNavigate()
+  const location = useLocation()
   const setAuth = useAuthStore((s) => s.setAuth)
   const { toast } = useToast()
 
@@ -16,7 +17,8 @@ export function useAuthMutation(mutationFn: AuthMutationFn) {
     mutationFn,
     onSuccess: (data) => {
       setAuth(data.accessToken, data.id, data.nickname)
-      navigate('/')
+      const from = (location.state as { from?: string } | null)?.from ?? '/'
+      navigate(from, { replace: true })
     },
     onError: (error) => {
       const { code } = extractApiError(error)

--- a/front/src/features/auth/hooks/useLogin.ts
+++ b/front/src/features/auth/hooks/useLogin.ts
@@ -1,24 +1,6 @@
-import { useMutation } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
 import { login } from '../api/authApi'
-import { useAuthStore } from '../stores/authStore'
-import { extractApiError, getErrorMessage } from '../../../shared/api/apiError'
-import { useToast } from '../../../shared/components/ui/Toast'
+import { useAuthMutation } from './useAuthMutation'
 
 export function useLogin() {
-  const navigate = useNavigate()
-  const setAuth = useAuthStore((s) => s.setAuth)
-  const { toast } = useToast()
-
-  return useMutation({
-    mutationFn: login,
-    onSuccess: (data) => {
-      setAuth(data.accessToken, data.id, data.nickname)
-      navigate('/')
-    },
-    onError: (error) => {
-      const { code } = extractApiError(error)
-      toast(getErrorMessage(code), 'error')
-    },
-  })
+  return useAuthMutation(login)
 }

--- a/front/src/features/auth/hooks/useLogin.ts
+++ b/front/src/features/auth/hooks/useLogin.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { login } from '../api/authApi'
+import { useAuthStore } from '../stores/authStore'
+import { extractApiError, getErrorMessage } from '../../../shared/api/apiError'
+import { useToast } from '../../../shared/components/ui/Toast'
+
+export function useLogin() {
+  const navigate = useNavigate()
+  const setAuth = useAuthStore((s) => s.setAuth)
+  const { toast } = useToast()
+
+  return useMutation({
+    mutationFn: login,
+    onSuccess: (data) => {
+      setAuth(data.accessToken, data.id, data.nickname)
+      navigate('/')
+    },
+    onError: (error) => {
+      const { code } = extractApiError(error)
+      toast(getErrorMessage(code), 'error')
+    },
+  })
+}

--- a/front/src/features/auth/hooks/useRegister.ts
+++ b/front/src/features/auth/hooks/useRegister.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { signUp } from '../api/authApi'
+import { useAuthStore } from '../stores/authStore'
+import { extractApiError, getErrorMessage } from '../../../shared/api/apiError'
+import { useToast } from '../../../shared/components/ui/Toast'
+
+export function useRegister() {
+  const navigate = useNavigate()
+  const setAuth = useAuthStore((s) => s.setAuth)
+  const { toast } = useToast()
+
+  return useMutation({
+    mutationFn: signUp,
+    onSuccess: (data) => {
+      setAuth(data.accessToken, data.id, data.nickname)
+      navigate('/')
+    },
+    onError: (error) => {
+      const { code } = extractApiError(error)
+      toast(getErrorMessage(code), 'error')
+    },
+  })
+}

--- a/front/src/features/auth/hooks/useRegister.ts
+++ b/front/src/features/auth/hooks/useRegister.ts
@@ -1,24 +1,6 @@
-import { useMutation } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
 import { signUp } from '../api/authApi'
-import { useAuthStore } from '../stores/authStore'
-import { extractApiError, getErrorMessage } from '../../../shared/api/apiError'
-import { useToast } from '../../../shared/components/ui/Toast'
+import { useAuthMutation } from './useAuthMutation'
 
 export function useRegister() {
-  const navigate = useNavigate()
-  const setAuth = useAuthStore((s) => s.setAuth)
-  const { toast } = useToast()
-
-  return useMutation({
-    mutationFn: signUp,
-    onSuccess: (data) => {
-      setAuth(data.accessToken, data.id, data.nickname)
-      navigate('/')
-    },
-    onError: (error) => {
-      const { code } = extractApiError(error)
-      toast(getErrorMessage(code), 'error')
-    },
-  })
+  return useAuthMutation(signUp)
 }

--- a/front/src/features/auth/pages/LoginPage.tsx
+++ b/front/src/features/auth/pages/LoginPage.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useLogin } from '../hooks/useLogin'
 import { loginSchema, type LoginFormValues } from '../utils/validationSchemas'
 import AuthLayout from '../components/AuthLayout'
+import NicknameInput from '../components/NicknameInput'
 import PasswordInput from '../components/PasswordInput'
 
 const LoginPage = () => {
@@ -20,25 +21,31 @@ const LoginPage = () => {
   }
 
   return (
-    <AuthLayout title="로그인">
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
-        {/* 닉네임 */}
-        <div>
-          <label htmlFor="nickname" className="block text-sm text-auth-muted mb-1.5">닉네임</label>
-          <input
-            id="nickname"
-            {...register('nickname')}
-            type="text"
-            placeholder="닉네임을 입력하세요"
-            disabled={isPending}
-            className="w-full bg-auth-input text-auth-text placeholder-auth-outline rounded-xl px-4 py-3 text-sm outline-none border border-auth-outline/20 focus:border-auth-primary/50 transition-colors disabled:opacity-50"
-          />
-          {errors.nickname && (
-            <p className="mt-1.5 text-xs text-auth-error">{errors.nickname.message}</p>
-          )}
-        </div>
+    <AuthLayout
+      title="로그인"
+      subtitle="인터브아이에서 맞춤형 면접 연습을 시작하세요"
+      footer={
+        <>
+          계정이 없으신가요?{' '}
+          <Link
+            to="/register"
+            className="font-medium text-auth-primary hover:text-auth-secondary transition-colors"
+          >
+            회원가입 하기
+          </Link>
+        </>
+      }
+    >
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <NicknameInput
+          id="nickname"
+          label="닉네임"
+          registration={register('nickname')}
+          error={errors.nickname}
+          placeholder="닉네임을 입력하세요"
+          disabled={isPending}
+        />
 
-        {/* 비밀번호 */}
         <PasswordInput
           id="password"
           label="비밀번호"
@@ -48,22 +55,15 @@ const LoginPage = () => {
           disabled={isPending}
         />
 
-        {/* 로그인 버튼 */}
         <button
           type="submit"
           disabled={isPending}
-          className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-auth-primary to-auth-secondary hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+          className="w-full py-3 rounded-xl text-sm font-semibold text-white disabled:opacity-50 disabled:cursor-not-allowed transition-opacity hover:opacity-90 mt-2"
+          style={{ background: 'linear-gradient(135deg, #4648d4 0%, #6b38d4 100%)' }}
         >
           {isPending ? '로그인 중...' : '로그인'}
         </button>
       </form>
-
-      <p className="mt-6 text-center text-sm text-auth-muted">
-        계정이 없으신가요?{' '}
-        <Link to="/register" className="text-auth-primary hover:text-auth-secondary transition-colors">
-          회원가입
-        </Link>
-      </p>
     </AuthLayout>
   )
 }

--- a/front/src/features/auth/pages/LoginPage.tsx
+++ b/front/src/features/auth/pages/LoginPage.tsx
@@ -1,7 +1,104 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Eye, EyeOff } from 'lucide-react'
+import { useLogin } from '../hooks/useLogin'
+
+const schema = z.object({
+  nickname: z.string().min(4, '닉네임은 4자 이상 입력해주세요.').max(8, '닉네임은 8자 이하로 입력해주세요.'),
+  password: z.string().min(4, '비밀번호는 4자 이상 입력해주세요.').max(12, '비밀번호는 12자 이하로 입력해주세요.'),
+})
+
+type FormValues = z.infer<typeof schema>
+
 const LoginPage = () => {
+  const [showPassword, setShowPassword] = useState(false)
+  const { mutate: login, isPending } = useLogin()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+
+  const onSubmit = (data: FormValues) => {
+    login(data)
+  }
+
   return (
-    <div className="flex items-center justify-center min-h-screen">
-      <p className="text-gray-500">로그인 페이지 (구현 예정)</p>
+    <div className="min-h-screen flex items-center justify-center bg-[#060e20]">
+      <div className="w-full max-w-md px-6">
+        {/* 로고 */}
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-white font-[Manrope]">
+            Interv<span className="bg-gradient-to-r from-[#85adff] to-[#ac8aff] bg-clip-text text-transparent">AI</span>
+          </h1>
+          <p className="mt-2 text-sm text-[#a3aac4]">AI 면접 연습 서비스</p>
+        </div>
+
+        {/* 카드 */}
+        <div className="bg-[#0f1930] rounded-2xl p-8 shadow-[0_48px_96px_rgba(14,21,48,0.06)]">
+          <h2 className="text-xl font-semibold text-[#dee5ff] mb-6">로그인</h2>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+            {/* 닉네임 */}
+            <div>
+              <label className="block text-sm text-[#a3aac4] mb-1.5">닉네임</label>
+              <input
+                {...register('nickname')}
+                type="text"
+                placeholder="닉네임을 입력하세요"
+                className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 focus:ring-0 transition-colors"
+              />
+              {errors.nickname && (
+                <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
+              )}
+            </div>
+
+            {/* 비밀번호 */}
+            <div>
+              <label className="block text-sm text-[#a3aac4] mb-1.5">비밀번호</label>
+              <div className="relative">
+                <input
+                  {...register('password')}
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="비밀번호를 입력하세요"
+                  className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
+                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                >
+                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                </button>
+              </div>
+              {errors.password && (
+                <p className="mt-1.5 text-xs text-[#ff716c]">{errors.password.message}</p>
+              )}
+            </div>
+
+            {/* 로그인 버튼 */}
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-[#85adff] to-[#ac8aff] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+            >
+              {isPending ? '로그인 중...' : '로그인'}
+            </button>
+          </form>
+
+          <p className="mt-6 text-center text-sm text-[#a3aac4]">
+            계정이 없으신가요?{' '}
+            <Link to="/register" className="text-[#85adff] hover:text-[#ac8aff] transition-colors">
+              회원가입
+            </Link>
+          </p>
+        </div>
+      </div>
     </div>
   )
 }

--- a/front/src/features/auth/pages/LoginPage.tsx
+++ b/front/src/features/auth/pages/LoginPage.tsx
@@ -7,8 +7,8 @@ import { Eye, EyeOff } from 'lucide-react'
 import { useLogin } from '../hooks/useLogin'
 
 const schema = z.object({
-  nickname: z.string().min(4, '닉네임은 4자 이상 입력해주세요.').max(8, '닉네임은 8자 이하로 입력해주세요.'),
-  password: z.string().min(4, '비밀번호는 4자 이상 입력해주세요.').max(12, '비밀번호는 12자 이하로 입력해주세요.'),
+  nickname: z.string().min(1, '닉네임을 입력해주세요.'),
+  password: z.string().min(1, '비밀번호를 입력해주세요.'),
 })
 
 type FormValues = z.infer<typeof schema>

--- a/front/src/features/auth/pages/LoginPage.tsx
+++ b/front/src/features/auth/pages/LoginPage.tsx
@@ -1,14 +1,12 @@
-import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Eye, EyeOff } from 'lucide-react'
 import { useLogin } from '../hooks/useLogin'
 import { loginSchema, type LoginFormValues } from '../utils/validationSchemas'
 import AuthLayout from '../components/AuthLayout'
+import PasswordInput from '../components/PasswordInput'
 
 const LoginPage = () => {
-  const [showPassword, setShowPassword] = useState(false)
   const { mutate: login, isPending } = useLogin()
 
   const {
@@ -26,59 +24,43 @@ const LoginPage = () => {
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
         {/* 닉네임 */}
         <div>
-          <label htmlFor="nickname" className="block text-sm text-[#a3aac4] mb-1.5">닉네임</label>
+          <label htmlFor="nickname" className="block text-sm text-auth-muted mb-1.5">닉네임</label>
           <input
             id="nickname"
             {...register('nickname')}
             type="text"
             placeholder="닉네임을 입력하세요"
             disabled={isPending}
-            className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
+            className="w-full bg-auth-input text-auth-text placeholder-auth-outline rounded-xl px-4 py-3 text-sm outline-none border border-auth-outline/20 focus:border-auth-primary/50 transition-colors disabled:opacity-50"
           />
           {errors.nickname && (
-            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
+            <p className="mt-1.5 text-xs text-auth-error">{errors.nickname.message}</p>
           )}
         </div>
 
         {/* 비밀번호 */}
-        <div>
-          <label htmlFor="password" className="block text-sm text-[#a3aac4] mb-1.5">비밀번호</label>
-          <div className="relative">
-            <input
-              id="password"
-              {...register('password')}
-              type={showPassword ? 'text' : 'password'}
-              placeholder="비밀번호를 입력하세요"
-              disabled={isPending}
-              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
-            />
-            <button
-              type="button"
-              onClick={() => setShowPassword((v) => !v)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
-              aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-            >
-              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-            </button>
-          </div>
-          {errors.password && (
-            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.password.message}</p>
-          )}
-        </div>
+        <PasswordInput
+          id="password"
+          label="비밀번호"
+          registration={register('password')}
+          error={errors.password}
+          placeholder="비밀번호를 입력하세요"
+          disabled={isPending}
+        />
 
         {/* 로그인 버튼 */}
         <button
           type="submit"
           disabled={isPending}
-          className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-[#85adff] to-[#ac8aff] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+          className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-auth-primary to-auth-secondary hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
         >
           {isPending ? '로그인 중...' : '로그인'}
         </button>
       </form>
 
-      <p className="mt-6 text-center text-sm text-[#a3aac4]">
+      <p className="mt-6 text-center text-sm text-auth-muted">
         계정이 없으신가요?{' '}
-        <Link to="/register" className="text-[#85adff] hover:text-[#ac8aff] transition-colors">
+        <Link to="/register" className="text-auth-primary hover:text-auth-secondary transition-colors">
           회원가입
         </Link>
       </p>

--- a/front/src/features/auth/pages/LoginPage.tsx
+++ b/front/src/features/auth/pages/LoginPage.tsx
@@ -32,7 +32,8 @@ const LoginPage = () => {
             {...register('nickname')}
             type="text"
             placeholder="닉네임을 입력하세요"
-            className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+            disabled={isPending}
+            className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
           />
           {errors.nickname && (
             <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
@@ -48,7 +49,8 @@ const LoginPage = () => {
               {...register('password')}
               type={showPassword ? 'text' : 'password'}
               placeholder="비밀번호를 입력하세요"
-              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+              disabled={isPending}
+              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
             />
             <button
               type="button"

--- a/front/src/features/auth/pages/LoginPage.tsx
+++ b/front/src/features/auth/pages/LoginPage.tsx
@@ -1,17 +1,11 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
-import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Eye, EyeOff } from 'lucide-react'
 import { useLogin } from '../hooks/useLogin'
-
-const schema = z.object({
-  nickname: z.string().min(1, '닉네임을 입력해주세요.'),
-  password: z.string().min(1, '비밀번호를 입력해주세요.'),
-})
-
-type FormValues = z.infer<typeof schema>
+import { loginSchema, type LoginFormValues } from '../utils/validationSchemas'
+import AuthLayout from '../components/AuthLayout'
 
 const LoginPage = () => {
   const [showPassword, setShowPassword] = useState(false)
@@ -21,85 +15,72 @@ const LoginPage = () => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+  } = useForm<LoginFormValues>({ resolver: zodResolver(loginSchema) })
 
-  const onSubmit = (data: FormValues) => {
+  const onSubmit = (data: LoginFormValues) => {
     login(data)
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#060e20]">
-      <div className="w-full max-w-md px-6">
-        {/* 로고 */}
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold tracking-tight text-white font-[Manrope]">
-            Interv<span className="bg-gradient-to-r from-[#85adff] to-[#ac8aff] bg-clip-text text-transparent">AI</span>
-          </h1>
-          <p className="mt-2 text-sm text-[#a3aac4]">AI 면접 연습 서비스</p>
+    <AuthLayout title="로그인">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+        {/* 닉네임 */}
+        <div>
+          <label htmlFor="nickname" className="block text-sm text-[#a3aac4] mb-1.5">닉네임</label>
+          <input
+            id="nickname"
+            {...register('nickname')}
+            type="text"
+            placeholder="닉네임을 입력하세요"
+            className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+          />
+          {errors.nickname && (
+            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
+          )}
         </div>
 
-        {/* 카드 */}
-        <div className="bg-[#0f1930] rounded-2xl p-8 shadow-[0_48px_96px_rgba(14,21,48,0.06)]">
-          <h2 className="text-xl font-semibold text-[#dee5ff] mb-6">로그인</h2>
-
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
-            {/* 닉네임 */}
-            <div>
-              <label className="block text-sm text-[#a3aac4] mb-1.5">닉네임</label>
-              <input
-                {...register('nickname')}
-                type="text"
-                placeholder="닉네임을 입력하세요"
-                className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 focus:ring-0 transition-colors"
-              />
-              {errors.nickname && (
-                <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
-              )}
-            </div>
-
-            {/* 비밀번호 */}
-            <div>
-              <label className="block text-sm text-[#a3aac4] mb-1.5">비밀번호</label>
-              <div className="relative">
-                <input
-                  {...register('password')}
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder="비밀번호를 입력하세요"
-                  className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
-                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-                >
-                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-                </button>
-              </div>
-              {errors.password && (
-                <p className="mt-1.5 text-xs text-[#ff716c]">{errors.password.message}</p>
-              )}
-            </div>
-
-            {/* 로그인 버튼 */}
+        {/* 비밀번호 */}
+        <div>
+          <label htmlFor="password" className="block text-sm text-[#a3aac4] mb-1.5">비밀번호</label>
+          <div className="relative">
+            <input
+              id="password"
+              {...register('password')}
+              type={showPassword ? 'text' : 'password'}
+              placeholder="비밀번호를 입력하세요"
+              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+            />
             <button
-              type="submit"
-              disabled={isPending}
-              className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-[#85adff] to-[#ac8aff] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
+              aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
             >
-              {isPending ? '로그인 중...' : '로그인'}
+              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
             </button>
-          </form>
-
-          <p className="mt-6 text-center text-sm text-[#a3aac4]">
-            계정이 없으신가요?{' '}
-            <Link to="/register" className="text-[#85adff] hover:text-[#ac8aff] transition-colors">
-              회원가입
-            </Link>
-          </p>
+          </div>
+          {errors.password && (
+            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.password.message}</p>
+          )}
         </div>
-      </div>
-    </div>
+
+        {/* 로그인 버튼 */}
+        <button
+          type="submit"
+          disabled={isPending}
+          className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-[#85adff] to-[#ac8aff] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+        >
+          {isPending ? '로그인 중...' : '로그인'}
+        </button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-[#a3aac4]">
+        계정이 없으신가요?{' '}
+        <Link to="/register" className="text-[#85adff] hover:text-[#ac8aff] transition-colors">
+          회원가입
+        </Link>
+      </p>
+    </AuthLayout>
   )
 }
 

--- a/front/src/features/auth/pages/RegisterPage.tsx
+++ b/front/src/features/auth/pages/RegisterPage.tsx
@@ -1,15 +1,12 @@
-import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Eye, EyeOff } from 'lucide-react'
 import { useRegister } from '../hooks/useRegister'
 import { registerSchema, type RegisterFormValues } from '../utils/validationSchemas'
 import AuthLayout from '../components/AuthLayout'
+import PasswordInput from '../components/PasswordInput'
 
 const RegisterPage = () => {
-  const [showPassword, setShowPassword] = useState(false)
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const { mutate: registerUser, isPending } = useRegister()
 
   const {
@@ -27,8 +24,8 @@ const RegisterPage = () => {
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
         {/* 닉네임 */}
         <div>
-          <label htmlFor="nickname" className="block text-sm text-[#a3aac4] mb-1.5">
-            닉네임 <span className="text-[#40485d]">(4~8자)</span>
+          <label htmlFor="nickname" className="block text-sm text-auth-muted mb-1.5">
+            닉네임 <span className="text-auth-outline">(4~8자)</span>
           </label>
           <input
             id="nickname"
@@ -36,82 +33,47 @@ const RegisterPage = () => {
             type="text"
             placeholder="사용할 닉네임을 입력하세요"
             disabled={isPending}
-            className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
+            className="w-full bg-auth-input text-auth-text placeholder-auth-outline rounded-xl px-4 py-3 text-sm outline-none border border-auth-outline/20 focus:border-auth-primary/50 transition-colors disabled:opacity-50"
           />
           {errors.nickname && (
-            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
+            <p className="mt-1.5 text-xs text-auth-error">{errors.nickname.message}</p>
           )}
         </div>
 
         {/* 비밀번호 */}
-        <div>
-          <label htmlFor="password" className="block text-sm text-[#a3aac4] mb-1.5">
-            비밀번호 <span className="text-[#40485d]">(4~12자)</span>
-          </label>
-          <div className="relative">
-            <input
-              id="password"
-              {...register('password')}
-              type={showPassword ? 'text' : 'password'}
-              placeholder="사용할 비밀번호를 입력하세요"
-              disabled={isPending}
-              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
-            />
-            <button
-              type="button"
-              onClick={() => setShowPassword((v) => !v)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
-              aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-            >
-              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-            </button>
-          </div>
-          {errors.password && (
-            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.password.message}</p>
-          )}
-        </div>
+        <PasswordInput
+          id="password"
+          label="비밀번호"
+          hint="(4~12자)"
+          registration={register('password')}
+          error={errors.password}
+          placeholder="사용할 비밀번호를 입력하세요"
+          disabled={isPending}
+        />
 
         {/* 비밀번호 확인 */}
-        <div>
-          <label htmlFor="confirmPassword" className="block text-sm text-[#a3aac4] mb-1.5">
-            비밀번호 확인
-          </label>
-          <div className="relative">
-            <input
-              id="confirmPassword"
-              {...register('confirmPassword')}
-              type={showConfirmPassword ? 'text' : 'password'}
-              placeholder="비밀번호를 다시 입력하세요"
-              disabled={isPending}
-              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
-            />
-            <button
-              type="button"
-              onClick={() => setShowConfirmPassword((v) => !v)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
-              aria-label={showConfirmPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-            >
-              {showConfirmPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-            </button>
-          </div>
-          {errors.confirmPassword && (
-            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.confirmPassword.message}</p>
-          )}
-        </div>
+        <PasswordInput
+          id="confirmPassword"
+          label="비밀번호 확인"
+          registration={register('confirmPassword')}
+          error={errors.confirmPassword}
+          placeholder="비밀번호를 다시 입력하세요"
+          disabled={isPending}
+        />
 
         {/* 회원가입 버튼 */}
         <button
           type="submit"
           disabled={isPending}
-          className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-[#85adff] to-[#ac8aff] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+          className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-auth-primary to-auth-secondary hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
         >
           {isPending ? '가입 중...' : '회원가입'}
         </button>
       </form>
 
-      <p className="mt-6 text-center text-sm text-[#a3aac4]">
+      <p className="mt-6 text-center text-sm text-auth-muted">
         이미 계정이 있으신가요?{' '}
-        <Link to="/login" className="text-[#85adff] hover:text-[#ac8aff] transition-colors">
+        <Link to="/login" className="text-auth-primary hover:text-auth-secondary transition-colors">
           로그인
         </Link>
       </p>

--- a/front/src/features/auth/pages/RegisterPage.tsx
+++ b/front/src/features/auth/pages/RegisterPage.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useRegister } from '../hooks/useRegister'
 import { registerSchema, type RegisterFormValues } from '../utils/validationSchemas'
 import AuthLayout from '../components/AuthLayout'
+import NicknameInput from '../components/NicknameInput'
 import PasswordInput from '../components/PasswordInput'
 
 const RegisterPage = () => {
@@ -20,27 +21,32 @@ const RegisterPage = () => {
   }
 
   return (
-    <AuthLayout title="회원가입">
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
-        {/* 닉네임 */}
-        <div>
-          <label htmlFor="nickname" className="block text-sm text-auth-muted mb-1.5">
-            닉네임 <span className="text-auth-outline">(4~8자)</span>
-          </label>
-          <input
-            id="nickname"
-            {...register('nickname')}
-            type="text"
-            placeholder="사용할 닉네임을 입력하세요"
-            disabled={isPending}
-            className="w-full bg-auth-input text-auth-text placeholder-auth-outline rounded-xl px-4 py-3 text-sm outline-none border border-auth-outline/20 focus:border-auth-primary/50 transition-colors disabled:opacity-50"
-          />
-          {errors.nickname && (
-            <p className="mt-1.5 text-xs text-auth-error">{errors.nickname.message}</p>
-          )}
-        </div>
+    <AuthLayout
+      title="회원가입"
+      subtitle="인터브아이에서 AI 면접 연습을 시작하세요"
+      footer={
+        <>
+          이미 계정이 있으신가요?{' '}
+          <Link
+            to="/login"
+            className="font-medium text-auth-primary hover:text-auth-secondary transition-colors"
+          >
+            로그인
+          </Link>
+        </>
+      }
+    >
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <NicknameInput
+          id="nickname"
+          label="닉네임"
+          hint="(4~8자)"
+          registration={register('nickname')}
+          error={errors.nickname}
+          placeholder="사용할 닉네임을 입력하세요"
+          disabled={isPending}
+        />
 
-        {/* 비밀번호 */}
         <PasswordInput
           id="password"
           label="비밀번호"
@@ -51,7 +57,6 @@ const RegisterPage = () => {
           disabled={isPending}
         />
 
-        {/* 비밀번호 확인 */}
         <PasswordInput
           id="confirmPassword"
           label="비밀번호 확인"
@@ -61,22 +66,15 @@ const RegisterPage = () => {
           disabled={isPending}
         />
 
-        {/* 회원가입 버튼 */}
         <button
           type="submit"
           disabled={isPending}
-          className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-auth-primary to-auth-secondary hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+          className="w-full py-3 rounded-xl text-sm font-semibold text-white disabled:opacity-50 disabled:cursor-not-allowed transition-opacity hover:opacity-90 mt-2"
+          style={{ background: 'linear-gradient(135deg, #4648d4 0%, #6b38d4 100%)' }}
         >
           {isPending ? '가입 중...' : '회원가입'}
         </button>
       </form>
-
-      <p className="mt-6 text-center text-sm text-auth-muted">
-        이미 계정이 있으신가요?{' '}
-        <Link to="/login" className="text-auth-primary hover:text-auth-secondary transition-colors">
-          로그인
-        </Link>
-      </p>
     </AuthLayout>
   )
 }

--- a/front/src/features/auth/pages/RegisterPage.tsx
+++ b/front/src/features/auth/pages/RegisterPage.tsx
@@ -1,17 +1,11 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
-import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Eye, EyeOff } from 'lucide-react'
 import { useRegister } from '../hooks/useRegister'
-
-const schema = z.object({
-  nickname: z.string().min(4, '닉네임은 4자 이상 입력해주세요.').max(8, '닉네임은 8자 이하로 입력해주세요.'),
-  password: z.string().min(4, '비밀번호는 4자 이상 입력해주세요.').max(12, '비밀번호는 12자 이하로 입력해주세요.'),
-})
-
-type FormValues = z.infer<typeof schema>
+import { registerSchema, type RegisterFormValues } from '../utils/validationSchemas'
+import AuthLayout from '../components/AuthLayout'
 
 const RegisterPage = () => {
   const [showPassword, setShowPassword] = useState(false)
@@ -21,89 +15,76 @@ const RegisterPage = () => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+  } = useForm<RegisterFormValues>({ resolver: zodResolver(registerSchema) })
 
-  const onSubmit = (data: FormValues) => {
+  const onSubmit = (data: RegisterFormValues) => {
     registerUser(data)
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#060e20]">
-      <div className="w-full max-w-md px-6">
-        {/* 로고 */}
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold tracking-tight text-white font-[Manrope]">
-            Interv<span className="bg-gradient-to-r from-[#85adff] to-[#ac8aff] bg-clip-text text-transparent">AI</span>
-          </h1>
-          <p className="mt-2 text-sm text-[#a3aac4]">AI 면접 연습 서비스</p>
+    <AuthLayout title="회원가입">
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+        {/* 닉네임 */}
+        <div>
+          <label htmlFor="nickname" className="block text-sm text-[#a3aac4] mb-1.5">
+            닉네임 <span className="text-[#40485d]">(4~8자)</span>
+          </label>
+          <input
+            id="nickname"
+            {...register('nickname')}
+            type="text"
+            placeholder="사용할 닉네임을 입력하세요"
+            className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+          />
+          {errors.nickname && (
+            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
+          )}
         </div>
 
-        {/* 카드 */}
-        <div className="bg-[#0f1930] rounded-2xl p-8 shadow-[0_48px_96px_rgba(14,21,48,0.06)]">
-          <h2 className="text-xl font-semibold text-[#dee5ff] mb-6">회원가입</h2>
-
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
-            {/* 닉네임 */}
-            <div>
-              <label className="block text-sm text-[#a3aac4] mb-1.5">
-                닉네임 <span className="text-[#40485d]">(4~8자)</span>
-              </label>
-              <input
-                {...register('nickname')}
-                type="text"
-                placeholder="사용할 닉네임을 입력하세요"
-                className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
-              />
-              {errors.nickname && (
-                <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
-              )}
-            </div>
-
-            {/* 비밀번호 */}
-            <div>
-              <label className="block text-sm text-[#a3aac4] mb-1.5">
-                비밀번호 <span className="text-[#40485d]">(4~12자)</span>
-              </label>
-              <div className="relative">
-                <input
-                  {...register('password')}
-                  type={showPassword ? 'text' : 'password'}
-                  placeholder="사용할 비밀번호를 입력하세요"
-                  className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
-                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
-                >
-                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
-                </button>
-              </div>
-              {errors.password && (
-                <p className="mt-1.5 text-xs text-[#ff716c]">{errors.password.message}</p>
-              )}
-            </div>
-
-            {/* 회원가입 버튼 */}
+        {/* 비밀번호 */}
+        <div>
+          <label htmlFor="password" className="block text-sm text-[#a3aac4] mb-1.5">
+            비밀번호 <span className="text-[#40485d]">(4~12자)</span>
+          </label>
+          <div className="relative">
+            <input
+              id="password"
+              {...register('password')}
+              type={showPassword ? 'text' : 'password'}
+              placeholder="사용할 비밀번호를 입력하세요"
+              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+            />
             <button
-              type="submit"
-              disabled={isPending}
-              className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-[#85adff] to-[#ac8aff] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
+              aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
             >
-              {isPending ? '가입 중...' : '회원가입'}
+              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
             </button>
-          </form>
-
-          <p className="mt-6 text-center text-sm text-[#a3aac4]">
-            이미 계정이 있으신가요?{' '}
-            <Link to="/login" className="text-[#85adff] hover:text-[#ac8aff] transition-colors">
-              로그인
-            </Link>
-          </p>
+          </div>
+          {errors.password && (
+            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.password.message}</p>
+          )}
         </div>
-      </div>
-    </div>
+
+        {/* 회원가입 버튼 */}
+        <button
+          type="submit"
+          disabled={isPending}
+          className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-[#85adff] to-[#ac8aff] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+        >
+          {isPending ? '가입 중...' : '회원가입'}
+        </button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-[#a3aac4]">
+        이미 계정이 있으신가요?{' '}
+        <Link to="/login" className="text-[#85adff] hover:text-[#ac8aff] transition-colors">
+          로그인
+        </Link>
+      </p>
+    </AuthLayout>
   )
 }
 

--- a/front/src/features/auth/pages/RegisterPage.tsx
+++ b/front/src/features/auth/pages/RegisterPage.tsx
@@ -1,7 +1,108 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Eye, EyeOff } from 'lucide-react'
+import { useRegister } from '../hooks/useRegister'
+
+const schema = z.object({
+  nickname: z.string().min(4, '닉네임은 4자 이상 입력해주세요.').max(8, '닉네임은 8자 이하로 입력해주세요.'),
+  password: z.string().min(4, '비밀번호는 4자 이상 입력해주세요.').max(12, '비밀번호는 12자 이하로 입력해주세요.'),
+})
+
+type FormValues = z.infer<typeof schema>
+
 const RegisterPage = () => {
+  const [showPassword, setShowPassword] = useState(false)
+  const { mutate: registerUser, isPending } = useRegister()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+
+  const onSubmit = (data: FormValues) => {
+    registerUser(data)
+  }
+
   return (
-    <div className="flex items-center justify-center min-h-screen">
-      <p className="text-gray-500">회원가입 페이지 (구현 예정)</p>
+    <div className="min-h-screen flex items-center justify-center bg-[#060e20]">
+      <div className="w-full max-w-md px-6">
+        {/* 로고 */}
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold tracking-tight text-white font-[Manrope]">
+            Interv<span className="bg-gradient-to-r from-[#85adff] to-[#ac8aff] bg-clip-text text-transparent">AI</span>
+          </h1>
+          <p className="mt-2 text-sm text-[#a3aac4]">AI 면접 연습 서비스</p>
+        </div>
+
+        {/* 카드 */}
+        <div className="bg-[#0f1930] rounded-2xl p-8 shadow-[0_48px_96px_rgba(14,21,48,0.06)]">
+          <h2 className="text-xl font-semibold text-[#dee5ff] mb-6">회원가입</h2>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+            {/* 닉네임 */}
+            <div>
+              <label className="block text-sm text-[#a3aac4] mb-1.5">
+                닉네임 <span className="text-[#40485d]">(4~8자)</span>
+              </label>
+              <input
+                {...register('nickname')}
+                type="text"
+                placeholder="사용할 닉네임을 입력하세요"
+                className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+              />
+              {errors.nickname && (
+                <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
+              )}
+            </div>
+
+            {/* 비밀번호 */}
+            <div>
+              <label className="block text-sm text-[#a3aac4] mb-1.5">
+                비밀번호 <span className="text-[#40485d]">(4~12자)</span>
+              </label>
+              <div className="relative">
+                <input
+                  {...register('password')}
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="사용할 비밀번호를 입력하세요"
+                  className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
+                  aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+                >
+                  {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                </button>
+              </div>
+              {errors.password && (
+                <p className="mt-1.5 text-xs text-[#ff716c]">{errors.password.message}</p>
+              )}
+            </div>
+
+            {/* 회원가입 버튼 */}
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full py-3 rounded-xl text-sm font-semibold text-black bg-gradient-to-r from-[#85adff] to-[#ac8aff] hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity mt-2"
+            >
+              {isPending ? '가입 중...' : '회원가입'}
+            </button>
+          </form>
+
+          <p className="mt-6 text-center text-sm text-[#a3aac4]">
+            이미 계정이 있으신가요?{' '}
+            <Link to="/login" className="text-[#85adff] hover:text-[#ac8aff] transition-colors">
+              로그인
+            </Link>
+          </p>
+        </div>
+      </div>
     </div>
   )
 }

--- a/front/src/features/auth/pages/RegisterPage.tsx
+++ b/front/src/features/auth/pages/RegisterPage.tsx
@@ -9,6 +9,7 @@ import AuthLayout from '../components/AuthLayout'
 
 const RegisterPage = () => {
   const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const { mutate: registerUser, isPending } = useRegister()
 
   const {
@@ -18,7 +19,7 @@ const RegisterPage = () => {
   } = useForm<RegisterFormValues>({ resolver: zodResolver(registerSchema) })
 
   const onSubmit = (data: RegisterFormValues) => {
-    registerUser(data)
+    registerUser({ nickname: data.nickname, password: data.password })
   }
 
   return (
@@ -34,7 +35,8 @@ const RegisterPage = () => {
             {...register('nickname')}
             type="text"
             placeholder="사용할 닉네임을 입력하세요"
-            className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+            disabled={isPending}
+            className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
           />
           {errors.nickname && (
             <p className="mt-1.5 text-xs text-[#ff716c]">{errors.nickname.message}</p>
@@ -52,7 +54,8 @@ const RegisterPage = () => {
               {...register('password')}
               type={showPassword ? 'text' : 'password'}
               placeholder="사용할 비밀번호를 입력하세요"
-              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors"
+              disabled={isPending}
+              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
             />
             <button
               type="button"
@@ -65,6 +68,34 @@ const RegisterPage = () => {
           </div>
           {errors.password && (
             <p className="mt-1.5 text-xs text-[#ff716c]">{errors.password.message}</p>
+          )}
+        </div>
+
+        {/* 비밀번호 확인 */}
+        <div>
+          <label htmlFor="confirmPassword" className="block text-sm text-[#a3aac4] mb-1.5">
+            비밀번호 확인
+          </label>
+          <div className="relative">
+            <input
+              id="confirmPassword"
+              {...register('confirmPassword')}
+              type={showConfirmPassword ? 'text' : 'password'}
+              placeholder="비밀번호를 다시 입력하세요"
+              disabled={isPending}
+              className="w-full bg-[#141f38] text-[#dee5ff] placeholder-[#40485d] rounded-xl px-4 py-3 pr-11 text-sm outline-none border border-[#40485d]/20 focus:border-[#85adff]/50 transition-colors disabled:opacity-50"
+            />
+            <button
+              type="button"
+              onClick={() => setShowConfirmPassword((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-[#a3aac4] hover:text-[#dee5ff] transition-colors"
+              aria-label={showConfirmPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+            >
+              {showConfirmPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            </button>
+          </div>
+          {errors.confirmPassword && (
+            <p className="mt-1.5 text-xs text-[#ff716c]">{errors.confirmPassword.message}</p>
           )}
         </div>
 

--- a/front/src/features/auth/utils/validationSchemas.ts
+++ b/front/src/features/auth/utils/validationSchemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const loginSchema = z.object({
+  nickname: z.string().min(1, '닉네임을 입력해주세요.'),
+  password: z.string().min(1, '비밀번호를 입력해주세요.'),
+})
+
+export const registerSchema = z.object({
+  nickname: z
+    .string()
+    .min(4, '닉네임은 4자 이상 입력해주세요.')
+    .max(8, '닉네임은 8자 이하로 입력해주세요.'),
+  password: z
+    .string()
+    .min(4, '비밀번호는 4자 이상 입력해주세요.')
+    .max(12, '비밀번호는 12자 이하로 입력해주세요.'),
+})
+
+export type LoginFormValues = z.infer<typeof loginSchema>
+export type RegisterFormValues = z.infer<typeof registerSchema>

--- a/front/src/features/auth/utils/validationSchemas.ts
+++ b/front/src/features/auth/utils/validationSchemas.ts
@@ -5,16 +5,22 @@ export const loginSchema = z.object({
   password: z.string().min(1, '비밀번호를 입력해주세요.'),
 })
 
-export const registerSchema = z.object({
-  nickname: z
-    .string()
-    .min(4, '닉네임은 4자 이상 입력해주세요.')
-    .max(8, '닉네임은 8자 이하로 입력해주세요.'),
-  password: z
-    .string()
-    .min(4, '비밀번호는 4자 이상 입력해주세요.')
-    .max(12, '비밀번호는 12자 이하로 입력해주세요.'),
-})
+export const registerSchema = z
+  .object({
+    nickname: z
+      .string()
+      .min(4, '닉네임은 4자 이상 입력해주세요.')
+      .max(8, '닉네임은 8자 이하로 입력해주세요.'),
+    password: z
+      .string()
+      .min(4, '비밀번호는 4자 이상 입력해주세요.')
+      .max(12, '비밀번호는 12자 이하로 입력해주세요.'),
+    confirmPassword: z.string().min(1, '비밀번호 확인을 입력해주세요.'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  })
 
 export type LoginFormValues = z.infer<typeof loginSchema>
 export type RegisterFormValues = z.infer<typeof registerSchema>

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,3 +1,15 @@
+@theme {
+  --color-auth-bg: #060e20;
+  --color-auth-card: #0f1930;
+  --color-auth-input: #141f38;
+  --color-auth-outline: #40485d;
+  --color-auth-primary: #85adff;
+  --color-auth-secondary: #ac8aff;
+  --color-auth-text: #dee5ff;
+  --color-auth-muted: #a3aac4;
+  --color-auth-error: #ff716c;
+}
+
 :root {
   --text: #6b6375;
   --text-h: #08060d;

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,13 +1,17 @@
+@import "tailwindcss";
+
 @theme {
-  --color-auth-bg: #060e20;
-  --color-auth-card: #0f1930;
-  --color-auth-input: #141f38;
-  --color-auth-outline: #40485d;
-  --color-auth-primary: #85adff;
-  --color-auth-secondary: #ac8aff;
-  --color-auth-text: #dee5ff;
-  --color-auth-muted: #a3aac4;
-  --color-auth-error: #ff716c;
+  --color-auth-bg: #faf8ff;
+  --color-auth-card: rgba(255, 255, 255, 0.8);
+  --color-auth-input: #eaedff;
+  --color-auth-input-focus: #ffffff;
+  --color-auth-outline: #c7c4d7;
+  --color-auth-primary: #4648d4;
+  --color-auth-secondary: #6b38d4;
+  --color-auth-text: #131b2e;
+  --color-auth-muted: #767586;
+  --color-auth-error: #ba1a1a;
+  --color-auth-surface: #ffffff;
 }
 
 :root {
@@ -63,15 +67,9 @@
 }
 
 #root {
-  width: 1126px;
-  max-width: 100%;
-  margin: 0 auto;
-  text-align: center;
-  border-inline: 1px solid var(--border);
   min-height: 100svh;
   display: flex;
   flex-direction: column;
-  box-sizing: border-box;
 }
 
 body {

--- a/front/src/shared/api/apiError.ts
+++ b/front/src/shared/api/apiError.ts
@@ -13,6 +13,7 @@ export const ERROR_MESSAGES: Record<string, string> = {
   INVALID_TOKEN: '인증이 만료되었습니다. 다시 로그인해주세요.',
   EXPIRED_TOKEN: '인증이 만료되었습니다. 다시 로그인해주세요.',
   LOGIN_FAILED: '닉네임 또는 비밀번호가 올바르지 않습니다.',
+  DUPLICATE_NICKNAME: '이미 사용 중인 닉네임입니다.',
   // 면접
   INTERVIEW_NOT_FOUND: '면접을 찾을 수 없습니다.',
   INTERVIEW_ACCESS_DENIED: '접근 권한이 없습니다.',

--- a/front/src/shared/api/constants.ts
+++ b/front/src/shared/api/constants.ts
@@ -4,4 +4,8 @@ export const API_PATHS = {
   auth: {
     refresh: '/api/auth/refresh',
   },
+  users: {
+    login: '/api/users/login',
+    signUp: '/api/users/sign-up',
+  },
 } as const

--- a/front/src/shared/components/layout/PrivateRoute.tsx
+++ b/front/src/shared/components/layout/PrivateRoute.tsx
@@ -1,11 +1,12 @@
-import { Navigate, Outlet } from 'react-router-dom'
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useAuthStore } from '../../../features/auth/stores/authStore'
 
 const PrivateRoute = () => {
   const accessToken = useAuthStore((s) => s.accessToken)
+  const location = useLocation()
 
   if (!accessToken) {
-    return <Navigate to="/login" replace />
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />
   }
 
   return <Outlet />

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: { '@': path.resolve(__dirname, './src') },
   },


### PR DESCRIPTION
## Summary
- `features/auth/api/authApi.ts`: login / signUp API 함수 구현
- `features/auth/hooks/useLogin.ts`, `useRegister.ts`: useMutation 훅, 성공 시 authStore 갱신 및 리다이렉트
- `features/auth/pages/LoginPage.tsx`: 로그인 페이지 UI
- `features/auth/pages/RegisterPage.tsx`: 회원가입 페이지 UI
- `shared/api/apiError.ts`: DUPLICATE_NICKNAME 에러 메시지 추가

## Details
- **폼 검증**: react-hook-form + zod (닉네임 4~8자, 비밀번호 4~12자)
- **비밀번호**: 눈 아이콘 표시/숨기기 토글 (lucide-react)
- **에러 처리**: API 에러 코드 → 한글 토스트 메시지
- **디자인**: Stitch MCP 생성 디자인 기반 다크 테마 (배경 `#060e20`, 블루~퍼플 그라데이션 버튼)
- **의존성**: lucide-react 추가

## Test plan
- [ ] `/login` 접속 → 닉네임·비밀번호 입력 → 로그인 성공 시 `/` 이동
- [ ] `/register` 접속 → 가입 성공 시 `/` 이동
- [ ] 닉네임 3자 입력 시 폼 에러 메시지 표시
- [ ] 잘못된 자격증명 → 토스트 에러 표시
- [ ] `npm run typecheck` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)