### PR TITLE
[FE] 대시보드 페이지 구현

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -104,6 +104,13 @@ Bean Validation 실패 시 아래 형식으로 반환됩니다.
 | `JUNIOR` | 주니어 |
 | `SENIOR` | 시니어 |
 
+### SessionStatus
+
+| 값 | 설명 |
+|----|------|
+| `IN_PROGRESS` | 진행 중 |
+| `COMPLETED` | 완료 |
+
 ---
 
 ## 사용자 인증
@@ -691,6 +698,68 @@ POST /api/interviews/{interviewId}/sessions/finish
 
 ```
 // Response 200 (body 없음)
+```
+
+---
+
+## 면접 목록 조회
+
+### 면접 목록 조회
+
+```
+GET /api/interviews
+```
+
+**인증**: 필요
+
+**Query Parameters**
+
+| 파라미터 | 타입 | 기본값 | 설명 |
+|---------|------|--------|------|
+| `page` | Integer | 0 | 페이지 번호 (0부터 시작) |
+| `size` | Integer | 10 | 페이지 크기 |
+
+**Response** `200 OK`
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `content` | InterviewSummary[] | 면접 요약 목록 |
+| `totalElements` | Long | 전체 면접 수 |
+| `totalPages` | Integer | 전체 페이지 수 |
+| `last` | Boolean | 마지막 페이지 여부 |
+
+**InterviewSummary 구조**
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `id` | Long | 면접 ID |
+| `interviewType` | InterviewType | 면접 유형 |
+| `difficulty` | Difficulty | 난이도 |
+| `questionCount` | Integer | 질문 수 |
+| `sessionStatus` | SessionStatus | 세션 상태 (`IN_PROGRESS` / `COMPLETED`) |
+| `createdAt` | String (ISO 8601) | 면접 생성 시각 |
+
+**에러**: 없음 (인증된 사용자의 면접이 없으면 빈 목록 반환)
+
+**예시**
+
+```json
+// Response 200
+{
+  "content": [
+    {
+      "id": 1,
+      "interviewType": "CS",
+      "difficulty": "JUNIOR",
+      "questionCount": 5,
+      "sessionStatus": "COMPLETED",
+      "createdAt": "2026-04-10T12:34:56"
+    }
+  ],
+  "totalElements": 1,
+  "totalPages": 1,
+  "last": true
+}
 ```
 
 ---

--- a/front/src/app/router.tsx
+++ b/front/src/app/router.tsx
@@ -7,6 +7,7 @@ import DashboardPage from '../shared/pages/DashboardPage'
 import InterviewPage from '../features/interview/pages/InterviewPage'
 import ProfilePage from '../features/profile/pages/ProfilePage'
 import NotFoundPage from '../shared/pages/NotFoundPage'
+import HistoryPage from '../shared/pages/HistoryPage'
 
 const Router = () => {
   return (
@@ -19,6 +20,7 @@ const Router = () => {
           <Route path="/" element={<DashboardPage />} />
           <Route path="/interview" element={<InterviewPage />} />
           <Route path="/profile" element={<ProfilePage />} />
+          <Route path="/history" element={<HistoryPage />} />
         </Route>
       </Route>
 

--- a/front/src/features/dashboard/api/dashboardApi.ts
+++ b/front/src/features/dashboard/api/dashboardApi.ts
@@ -1,0 +1,26 @@
+import { httpClient } from '../../../shared/api/httpClient'
+import { API_PATHS } from '../../../shared/api/constants'
+import type { InterviewType, Difficulty, SessionStatus } from '../../../shared/types/enums'
+
+export interface InterviewSummary {
+  id: number
+  interviewType: InterviewType
+  difficulty: Difficulty
+  questionCount: number
+  sessionStatus: SessionStatus
+  createdAt: string
+}
+
+export interface InterviewListResponse {
+  content: InterviewSummary[]
+  totalElements: number
+  totalPages: number
+  last: boolean
+}
+
+export const getInterviewList = (params?: {
+  page?: number
+  size?: number
+}): Promise<InterviewListResponse> => {
+  return httpClient.get<InterviewListResponse>(API_PATHS.interviews.list, { params }).then((res) => res.data)
+}

--- a/front/src/features/dashboard/components/RecentHistorySection.tsx
+++ b/front/src/features/dashboard/components/RecentHistorySection.tsx
@@ -1,33 +1,26 @@
 import { Link } from 'react-router-dom'
 import type { InterviewSummary } from '../api/dashboardApi'
 import { InterviewType, SessionStatus } from '../../../shared/types/enums'
+import { formatDate } from '../../../shared/utils/date'
 
 interface RecentHistorySectionProps {
   items: InterviewSummary[]
 }
 
-const INTERVIEW_TYPE_LABEL: Record<string, string> = {
+const INTERVIEW_TYPE_LABEL: Record<InterviewType, string> = {
   [InterviewType.CS]: 'CS 기초',
   [InterviewType.PORTFOLIO]: '포트폴리오',
   [InterviewType.ALL]: '종합',
 }
 
-const SESSION_STATUS_LABEL: Record<string, string> = {
+const SESSION_STATUS_LABEL: Record<SessionStatus, string> = {
   [SessionStatus.IN_PROGRESS]: '진행 중',
   [SessionStatus.COMPLETED]: '완료',
 }
 
-const SESSION_STATUS_COLOR: Record<string, string> = {
+const SESSION_STATUS_COLOR: Record<SessionStatus, string> = {
   [SessionStatus.IN_PROGRESS]: 'text-amber-600 bg-amber-50',
   [SessionStatus.COMPLETED]: 'text-green-600 bg-green-50',
-}
-
-const formatDate = (createdAt: string): string => {
-  return new Date(createdAt).toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  })
 }
 
 const RecentHistorySection = ({ items }: RecentHistorySectionProps) => {
@@ -51,15 +44,15 @@ const RecentHistorySection = ({ items }: RecentHistorySectionProps) => {
             >
               <div>
                 <p className="text-[#131b2e] font-medium">
-                  {INTERVIEW_TYPE_LABEL[item.interviewType] ?? item.interviewType}
+                  {INTERVIEW_TYPE_LABEL[item.interviewType]}
                 </p>
                 <p className="text-sm text-[#131b2e]/50 mt-0.5">{formatDate(item.createdAt)}</p>
               </div>
               <div className="flex items-center gap-3">
                 <span
-                  className={`text-xs font-medium px-2 py-1 rounded-full ${SESSION_STATUS_COLOR[item.sessionStatus] ?? ''}`}
+                  className={`text-xs font-medium px-2 py-1 rounded-full ${SESSION_STATUS_COLOR[item.sessionStatus]}`}
                 >
-                  {SESSION_STATUS_LABEL[item.sessionStatus] ?? item.sessionStatus}
+                  {SESSION_STATUS_LABEL[item.sessionStatus]}
                 </span>
                 <span className="text-[#4648d4] text-lg">›</span>
               </div>

--- a/front/src/features/dashboard/components/RecentHistorySection.tsx
+++ b/front/src/features/dashboard/components/RecentHistorySection.tsx
@@ -1,0 +1,74 @@
+import { Link } from 'react-router-dom'
+import type { InterviewSummary } from '../api/dashboardApi'
+import { InterviewType, SessionStatus } from '../../../shared/types/enums'
+
+interface RecentHistorySectionProps {
+  items: InterviewSummary[]
+}
+
+const INTERVIEW_TYPE_LABEL: Record<string, string> = {
+  [InterviewType.CS]: 'CS 기초',
+  [InterviewType.PORTFOLIO]: '포트폴리오',
+  [InterviewType.ALL]: '종합',
+}
+
+const SESSION_STATUS_LABEL: Record<string, string> = {
+  [SessionStatus.IN_PROGRESS]: '진행 중',
+  [SessionStatus.COMPLETED]: '완료',
+}
+
+const SESSION_STATUS_COLOR: Record<string, string> = {
+  [SessionStatus.IN_PROGRESS]: 'text-amber-600 bg-amber-50',
+  [SessionStatus.COMPLETED]: 'text-green-600 bg-green-50',
+}
+
+const formatDate = (createdAt: string): string => {
+  return new Date(createdAt).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+}
+
+const RecentHistorySection = ({ items }: RecentHistorySectionProps) => {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-[#131b2e] font-bold text-lg">최근 면접 기록</h2>
+        <Link to="/history" className="text-sm text-[#4648d4] hover:underline">
+          더보기
+        </Link>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="text-[#131b2e]/40 text-center py-8">아직 면접 기록이 없습니다</p>
+      ) : (
+        <ul className="space-y-3">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="flex items-center justify-between p-4 bg-white rounded-xl border border-[#e2e7ff] hover:bg-[#faf8ff]"
+            >
+              <div>
+                <p className="text-[#131b2e] font-medium">
+                  {INTERVIEW_TYPE_LABEL[item.interviewType] ?? item.interviewType}
+                </p>
+                <p className="text-sm text-[#131b2e]/50 mt-0.5">{formatDate(item.createdAt)}</p>
+              </div>
+              <div className="flex items-center gap-3">
+                <span
+                  className={`text-xs font-medium px-2 py-1 rounded-full ${SESSION_STATUS_COLOR[item.sessionStatus] ?? ''}`}
+                >
+                  {SESSION_STATUS_LABEL[item.sessionStatus] ?? item.sessionStatus}
+                </span>
+                <span className="text-[#4648d4] text-lg">›</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default RecentHistorySection

--- a/front/src/features/dashboard/components/StatsSection.tsx
+++ b/front/src/features/dashboard/components/StatsSection.tsx
@@ -1,15 +1,8 @@
 import type { InterviewListResponse } from '../api/dashboardApi'
+import { formatDate } from '../../../shared/utils/date'
 
 interface StatsSectionProps {
   data: InterviewListResponse | undefined
-}
-
-const formatDate = (createdAt: string): string => {
-  return new Date(createdAt).toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  })
 }
 
 const StatsSection = ({ data }: StatsSectionProps) => {

--- a/front/src/features/dashboard/components/StatsSection.tsx
+++ b/front/src/features/dashboard/components/StatsSection.tsx
@@ -1,0 +1,33 @@
+import type { InterviewListResponse } from '../api/dashboardApi'
+
+interface StatsSectionProps {
+  data: InterviewListResponse | undefined
+}
+
+const formatDate = (createdAt: string): string => {
+  return new Date(createdAt).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+}
+
+const StatsSection = ({ data }: StatsSectionProps) => {
+  const totalCount = data?.totalElements ?? 0
+  const recentDate = data?.content[0]?.createdAt ? formatDate(data.content[0].createdAt) : '-'
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <div className="bg-[#dae2fd] rounded-xl p-5">
+        <p className="text-2xl font-bold text-[#131b2e]">{totalCount}회</p>
+        <p className="text-sm text-[#131b2e]/60 mt-1">총 면접 횟수</p>
+      </div>
+      <div className="bg-[#dae2fd] rounded-xl p-5">
+        <p className="text-2xl font-bold text-[#131b2e]">{recentDate}</p>
+        <p className="text-sm text-[#131b2e]/60 mt-1">최근 면접일</p>
+      </div>
+    </div>
+  )
+}
+
+export default StatsSection

--- a/front/src/features/dashboard/components/WelcomeSection.tsx
+++ b/front/src/features/dashboard/components/WelcomeSection.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'react-router-dom'
+import { useAuthStore } from '../../auth/stores/authStore'
+
+const WelcomeSection = () => {
+  const nickname = useAuthStore((s) => s.nickname)
+
+  return (
+    <div className="bg-[#eaedff] rounded-2xl p-8">
+      <h1 className="text-[#131b2e] text-2xl font-bold">{nickname}님, 반갑습니다!</h1>
+      <p className="text-[#131b2e]/70 mt-2">꾸준한 연습이 합격을 만듭니다. 오늘도 함께해요.</p>
+      <Link
+        to="/interview"
+        style={{ background: 'linear-gradient(135deg, #4648d4, #6b38d4)' }}
+        className="inline-block text-white rounded-lg px-6 py-3 font-semibold hover:opacity-90 transition-opacity mt-6"
+      >
+        면접 시작하기
+      </Link>
+    </div>
+  )
+}
+
+export default WelcomeSection

--- a/front/src/features/dashboard/hooks/useInterviewList.ts
+++ b/front/src/features/dashboard/hooks/useInterviewList.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from '../../../shared/types/queryKeys'
+import { getInterviewList } from '../api/dashboardApi'
+
+const useInterviewList = () => {
+  return useQuery({
+    queryKey: queryKeys.interviews.list(),
+    queryFn: () => getInterviewList({ size: 3 }),
+    staleTime: 60_000,
+    retry: false,
+  })
+}
+
+export default useInterviewList

--- a/front/src/shared/api/constants.ts
+++ b/front/src/shared/api/constants.ts
@@ -11,4 +11,7 @@ export const API_PATHS = {
   profile: {
     base: '/api/users/profile',
   },
+  interviews: {
+    list: '/api/interviews',
+  },
 } as const

--- a/front/src/shared/pages/DashboardPage.tsx
+++ b/front/src/shared/pages/DashboardPage.tsx
@@ -1,7 +1,39 @@
+import useInterviewList from '../../features/dashboard/hooks/useInterviewList'
+import WelcomeSection from '../../features/dashboard/components/WelcomeSection'
+import StatsSection from '../../features/dashboard/components/StatsSection'
+import RecentHistorySection from '../../features/dashboard/components/RecentHistorySection'
+import { extractApiError, getErrorMessage } from '../api/apiError'
+
 const DashboardPage = () => {
+  const { data, isLoading, isError, error } = useInterviewList()
+
+  if (isLoading) {
+    return (
+      <div className="bg-[#faf8ff] p-8 space-y-6 min-h-full animate-pulse">
+        <div className="bg-[#eaedff] rounded-2xl p-8 h-40" />
+        <div className="grid grid-cols-2 gap-4">
+          <div className="bg-[#dae2fd] rounded-xl p-5 h-24" />
+          <div className="bg-[#dae2fd] rounded-xl p-5 h-24" />
+        </div>
+        <div className="space-y-3">
+          <div className="bg-white rounded-xl border border-[#e2e7ff] p-4 h-16" />
+          <div className="bg-white rounded-xl border border-[#e2e7ff] p-4 h-16" />
+          <div className="bg-white rounded-xl border border-[#e2e7ff] p-4 h-16" />
+        </div>
+      </div>
+    )
+  }
+
+  const apiError = isError ? extractApiError(error) : null
+
   return (
-    <div className="p-8">
-      <p className="text-gray-500">대시보드 (구현 예정)</p>
+    <div className="bg-[#faf8ff] p-8 space-y-6 min-h-full">
+      <WelcomeSection />
+      <StatsSection data={data} />
+      {apiError && (
+        <p className="text-sm text-red-500">{getErrorMessage(apiError.code)}</p>
+      )}
+      <RecentHistorySection items={data?.content ?? []} />
     </div>
   )
 }

--- a/front/src/shared/pages/HistoryPage.tsx
+++ b/front/src/shared/pages/HistoryPage.tsx
@@ -1,0 +1,9 @@
+const HistoryPage = () => {
+  return (
+    <div className="p-8">
+      <p className="text-gray-500">히스토리 (구현 예정)</p>
+    </div>
+  )
+}
+
+export default HistoryPage

--- a/front/src/shared/types/enums.ts
+++ b/front/src/shared/types/enums.ts
@@ -52,3 +52,9 @@ export const CareerLevel = {
   SENIOR: 'SENIOR',
 } as const
 export type CareerLevel = (typeof CareerLevel)[keyof typeof CareerLevel]
+
+export const SessionStatus = {
+  IN_PROGRESS: 'IN_PROGRESS',
+  COMPLETED: 'COMPLETED',
+} as const
+export type SessionStatus = (typeof SessionStatus)[keyof typeof SessionStatus]

--- a/front/src/shared/types/queryKeys.ts
+++ b/front/src/shared/types/queryKeys.ts
@@ -8,4 +8,8 @@ export const queryKeys = {
     currentQuestion: (interviewId: number) =>
       ['interview', interviewId, 'currentQuestion'] as const,
   },
+  interviews: {
+    all: ['interviews'] as const,
+    list: () => ['interviews', 'list'] as const,
+  },
 } as const

--- a/front/src/shared/utils/date.ts
+++ b/front/src/shared/utils/date.ts
@@ -1,0 +1,7 @@
+export const formatDate = (dateStr: string): string => {
+  return new Date(dateStr).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+}


### PR DESCRIPTION
## Summary
- `GET /api/interviews` API 스펙 추가 (`docs/api.md`)
- `SessionStatus` enum, `interviews.list` API 경로, 쿼리 키 공유 타입 추가
- `features/dashboard/` 신규 생성 — API 함수, `useInterviewList` 훅, WelcomeSection / StatsSection / RecentHistorySection 컴포넌트
- `DashboardPage.tsx` stub → 실제 구현 (웰컴 섹션, 통계 카드, 최근 면접 기록)
- `HistoryPage.tsx` stub 생성 및 `/history` 라우트 등록

## Test plan
- [ ] `npm run typecheck` 통과
- [ ] `npm run lint` 통과
- [ ] 로그인 후 `/` 접근 시 닉네임 헤드라인 표시 확인
- [ ] "면접 시작하기" 클릭 시 `/interview` 이동 확인
- [ ] 면접 기록 없을 때 빈 상태 메시지 표시 확인
- [ ] 면접 기록 있을 때 최대 3개만 표시 확인
- [ ] "더보기" 클릭 시 `/history` 이동 확인
- [ ] API 에러 시 graceful degradation 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)