### PR TITLE
fix: restore session history in conversation order

### DIFF
--- a/front/src/features/interview/api/interviewApi.ts
+++ b/front/src/features/interview/api/interviewApi.ts
@@ -60,6 +60,7 @@ export interface SubmitAnswerResponse {
 
 export interface SessionHistoryItem {
   questionId: number
+  parentQuestionId: number | null
   answerId: number | null
   questionContent: string
   answerContent: string | null

--- a/front/src/features/interview/components/InterviewChatScreen.tsx
+++ b/front/src/features/interview/components/InterviewChatScreen.tsx
@@ -15,6 +15,7 @@ import ChatInputArea from './ChatInputArea'
 import AllQuestionsCompletedBanner from './AllQuestionsCompletedBanner'
 import FinishConfirmDialog from './FinishConfirmDialog'
 import type { ChatMessage } from '../types/chat'
+import { orderSessionHistory } from '../utils/sessionHistory'
 
 const InterviewChatScreen = () => {
   const {
@@ -109,10 +110,13 @@ const InterviewChatScreen = () => {
       .then((history) => {
         if (cancelled) return
 
+        const orderedHistory = orderSessionHistory(history)
+        const historyForRestore =
+          orderedHistory.length === history.length ? orderedHistory : history
         const restoredMessages: ChatMessage[] = []
         let mainQuestionCount = 0
 
-        for (const item of history) {
+        for (const item of historyForRestore) {
           if (item.answerId === null) {
             continue // 미답변 — appendAiQuestion이 처리
           }

--- a/front/src/features/interview/components/InterviewChatScreen.tsx
+++ b/front/src/features/interview/components/InterviewChatScreen.tsx
@@ -110,9 +110,7 @@ const InterviewChatScreen = () => {
       .then((history) => {
         if (cancelled) return
 
-        const orderedHistory = orderSessionHistory(history)
-        const historyForRestore =
-          orderedHistory.length === history.length ? orderedHistory : history
+        const historyForRestore = orderSessionHistory(history)
         const restoredMessages: ChatMessage[] = []
         let mainQuestionCount = 0
 

--- a/front/src/features/interview/utils/sessionHistory.ts
+++ b/front/src/features/interview/utils/sessionHistory.ts
@@ -9,35 +9,39 @@ export interface OrderedSessionHistoryItem extends SessionHistoryItem {
 export const orderSessionHistory = (
   history: SessionHistoryItem[],
 ): OrderedSessionHistoryItem[] => {
-  const sortNaturally = (items: SessionHistoryItem[]) =>
+  const sortRoots = (items: SessionHistoryItem[]) =>
     [...items].sort((a, b) => {
+      const aGroup = a.questionType === QuestionType.QUESTION ? 0 : 1
+      const bGroup = b.questionType === QuestionType.QUESTION ? 0 : 1
+      if (aGroup !== bGroup) return aGroup - bGroup
+
       const aIndex = a.questionType === QuestionType.QUESTION ? a.questionIndex : Number.MAX_SAFE_INTEGER
       const bIndex = b.questionType === QuestionType.QUESTION ? b.questionIndex : Number.MAX_SAFE_INTEGER
       const byIndex = aIndex - bIndex
       return byIndex !== 0 ? byIndex : a.questionId - b.questionId
     })
 
-  const byQuestionId = [...history].sort((a, b) => a.questionId - b.questionId)
   const effectiveParentByQuestionId = new Map<number, number | null>()
-  let previousByCreationOrder: SessionHistoryItem | null = null
+  let previousInResponse: SessionHistoryItem | null = null
 
-  for (const item of byQuestionId) {
+  for (const item of history) {
     if (item.parentQuestionId !== null) {
       effectiveParentByQuestionId.set(item.questionId, item.parentQuestionId)
-    } else if (item.questionType === QuestionType.FOLLOW_UP && previousByCreationOrder !== null) {
-      effectiveParentByQuestionId.set(item.questionId, previousByCreationOrder.questionId)
+    } else if (item.questionType === QuestionType.FOLLOW_UP && previousInResponse !== null) {
+      effectiveParentByQuestionId.set(item.questionId, previousInResponse.questionId)
     } else {
       effectiveParentByQuestionId.set(item.questionId, null)
     }
 
-    previousByCreationOrder = item
+    previousInResponse = item
   }
 
   const childrenByParentId = new Map<number, SessionHistoryItem[]>()
+  const questionIds = new Set(history.map((item) => item.questionId))
 
   for (const item of history) {
     const effectiveParentQuestionId = effectiveParentByQuestionId.get(item.questionId) ?? null
-    if (effectiveParentQuestionId === null) continue
+    if (effectiveParentQuestionId === null || !questionIds.has(effectiveParentQuestionId)) continue
     const children = childrenByParentId.get(effectiveParentQuestionId) ?? []
     children.push(item)
     childrenByParentId.set(effectiveParentQuestionId, children)
@@ -47,8 +51,10 @@ export const orderSessionHistory = (
     children.sort((a, b) => a.questionId - b.questionId)
   }
 
-  const rootQuestions = sortNaturally(history)
-    .filter((item) => (effectiveParentByQuestionId.get(item.questionId) ?? null) === null)
+  const rootQuestions = sortRoots(history).filter((item) => {
+    const effectiveParentQuestionId = effectiveParentByQuestionId.get(item.questionId) ?? null
+    return effectiveParentQuestionId === null || !questionIds.has(effectiveParentQuestionId)
+  })
 
   const ordered: OrderedSessionHistoryItem[] = []
   const visitedQuestionIds = new Set<number>()
@@ -81,7 +87,7 @@ export const orderSessionHistory = (
     mainQuestionOrder = nextMainQuestionOrder
   }
 
-  const remainingItems = sortNaturally(history).filter((item) => !visitedQuestionIds.has(item.questionId))
+  const remainingItems = history.filter((item) => !visitedQuestionIds.has(item.questionId))
   for (const item of remainingItems) {
     const nextMainQuestionOrder =
       item.questionType === QuestionType.QUESTION ? mainQuestionOrder + 1 : mainQuestionOrder

--- a/front/src/features/interview/utils/sessionHistory.ts
+++ b/front/src/features/interview/utils/sessionHistory.ts
@@ -1,0 +1,93 @@
+import { QuestionType } from '../../../shared/types/enums'
+import type { SessionHistoryItem } from '../api/interviewApi'
+
+export interface OrderedSessionHistoryItem extends SessionHistoryItem {
+  depth: number
+  mainQuestionOrder: number
+}
+
+export const orderSessionHistory = (
+  history: SessionHistoryItem[],
+): OrderedSessionHistoryItem[] => {
+  const sortNaturally = (items: SessionHistoryItem[]) =>
+    [...items].sort((a, b) => {
+      const aIndex = a.questionType === QuestionType.QUESTION ? a.questionIndex : Number.MAX_SAFE_INTEGER
+      const bIndex = b.questionType === QuestionType.QUESTION ? b.questionIndex : Number.MAX_SAFE_INTEGER
+      const byIndex = aIndex - bIndex
+      return byIndex !== 0 ? byIndex : a.questionId - b.questionId
+    })
+
+  const byQuestionId = [...history].sort((a, b) => a.questionId - b.questionId)
+  const effectiveParentByQuestionId = new Map<number, number | null>()
+  let previousByCreationOrder: SessionHistoryItem | null = null
+
+  for (const item of byQuestionId) {
+    if (item.parentQuestionId !== null) {
+      effectiveParentByQuestionId.set(item.questionId, item.parentQuestionId)
+    } else if (item.questionType === QuestionType.FOLLOW_UP && previousByCreationOrder !== null) {
+      effectiveParentByQuestionId.set(item.questionId, previousByCreationOrder.questionId)
+    } else {
+      effectiveParentByQuestionId.set(item.questionId, null)
+    }
+
+    previousByCreationOrder = item
+  }
+
+  const childrenByParentId = new Map<number, SessionHistoryItem[]>()
+
+  for (const item of history) {
+    const effectiveParentQuestionId = effectiveParentByQuestionId.get(item.questionId) ?? null
+    if (effectiveParentQuestionId === null) continue
+    const children = childrenByParentId.get(effectiveParentQuestionId) ?? []
+    children.push(item)
+    childrenByParentId.set(effectiveParentQuestionId, children)
+  }
+
+  for (const children of childrenByParentId.values()) {
+    children.sort((a, b) => a.questionId - b.questionId)
+  }
+
+  const rootQuestions = sortNaturally(history)
+    .filter((item) => (effectiveParentByQuestionId.get(item.questionId) ?? null) === null)
+
+  const ordered: OrderedSessionHistoryItem[] = []
+  const visitedQuestionIds = new Set<number>()
+
+  const appendDepthFirst = (
+    item: SessionHistoryItem,
+    depth: number,
+    mainQuestionOrder: number,
+  ) => {
+    if (visitedQuestionIds.has(item.questionId)) return
+    visitedQuestionIds.add(item.questionId)
+
+    ordered.push({
+      ...item,
+      depth,
+      mainQuestionOrder,
+    })
+
+    const children = childrenByParentId.get(item.questionId) ?? []
+    for (const child of children) {
+      appendDepthFirst(child, depth + 1, mainQuestionOrder)
+    }
+  }
+
+  let mainQuestionOrder = 0
+  for (const root of rootQuestions) {
+    const nextMainQuestionOrder =
+      root.questionType === QuestionType.QUESTION ? mainQuestionOrder + 1 : mainQuestionOrder
+    appendDepthFirst(root, 0, nextMainQuestionOrder)
+    mainQuestionOrder = nextMainQuestionOrder
+  }
+
+  const remainingItems = sortNaturally(history).filter((item) => !visitedQuestionIds.has(item.questionId))
+  for (const item of remainingItems) {
+    const nextMainQuestionOrder =
+      item.questionType === QuestionType.QUESTION ? mainQuestionOrder + 1 : mainQuestionOrder
+    appendDepthFirst(item, 0, nextMainQuestionOrder)
+    mainQuestionOrder = nextMainQuestionOrder
+  }
+
+  return ordered
+}

--- a/front/src/shared/pages/InterviewResultPage.tsx
+++ b/front/src/shared/pages/InterviewResultPage.tsx
@@ -11,7 +11,8 @@ const ResultItem = ({ item }: { item: OrderedSessionHistoryItem }) => {
   const [feedbackOpen, setFeedbackOpen] = useState(false)
   const isFollowUp = item.questionType === QuestionType.FOLLOW_UP
   const depthClass = item.depth > 0 ? 'ml-6 border-l-4 border-[#d7dcff]' : ''
-  const label = isFollowUp ? `Q${item.mainQuestionOrder} 꼬리 질문` : `Q${item.mainQuestionOrder}`
+  const displayOrder = Math.max(1, item.mainQuestionOrder)
+  const label = isFollowUp ? `Q${displayOrder} 꼬리 질문` : `Q${displayOrder}`
 
   return (
     <div className={`bg-white rounded-xl border border-[#c7cbf5] overflow-hidden ${depthClass}`}>

--- a/front/src/shared/pages/InterviewResultPage.tsx
+++ b/front/src/shared/pages/InterviewResultPage.tsx
@@ -3,20 +3,28 @@ import { useQuery } from '@tanstack/react-query'
 import { Loader2, ChevronDown, ChevronUp } from 'lucide-react'
 import { useState } from 'react'
 import { getSessionHistory } from '../../features/interview/api/interviewApi'
-import type { SessionHistoryItem } from '../../features/interview/api/interviewApi'
 import { QuestionType } from '../types/enums'
+import type { OrderedSessionHistoryItem } from '../../features/interview/utils/sessionHistory'
+import { orderSessionHistory } from '../../features/interview/utils/sessionHistory'
 
-const ResultItem = ({ item, index }: { item: SessionHistoryItem; index: number }) => {
+const ResultItem = ({ item }: { item: OrderedSessionHistoryItem }) => {
   const [feedbackOpen, setFeedbackOpen] = useState(false)
   const isFollowUp = item.questionType === QuestionType.FOLLOW_UP
+  const depthClass = item.depth > 0 ? 'ml-6 border-l-4 border-[#d7dcff]' : ''
+  const label = isFollowUp ? `Q${item.mainQuestionOrder} 꼬리 질문` : `Q${item.mainQuestionOrder}`
 
   return (
-    <div className="bg-white rounded-xl border border-[#c7cbf5] overflow-hidden">
+    <div className={`bg-white rounded-xl border border-[#c7cbf5] overflow-hidden ${depthClass}`}>
       <div className="px-5 py-4 border-b border-[#eaedff]">
         <div className="flex items-center gap-2 mb-2">
           <span className="text-xs font-medium text-[#4648d4] bg-[#eaedff] px-2 py-0.5 rounded-full">
-            {isFollowUp ? '꼬리 질문' : `Q${index + 1}`}
+            {label}
           </span>
+          {isFollowUp && item.parentQuestionId !== null && (
+            <span className="text-[11px] font-medium text-[#767586]">
+              이전 질문에 대한 추가 질문
+            </span>
+          )}
         </div>
         <p className="text-sm font-medium text-[#131b2e]">{item.questionContent}</p>
       </div>
@@ -88,8 +96,7 @@ const InterviewResultPage = () => {
 
   const mainQuestions = history.filter((item) => item.questionType === QuestionType.QUESTION)
   const answeredCount = history.filter((item) => item.answerId !== null).length
-
-  let mainIndex = -1
+  const orderedHistory = orderSessionHistory(history)
 
   return (
     <div className="min-h-screen bg-[#faf8ff]">
@@ -120,16 +127,9 @@ const InterviewResultPage = () => {
         </div>
 
         <div className="flex flex-col gap-4">
-          {history.map((item) => {
-            if (item.questionType === QuestionType.QUESTION) mainIndex++
-            return (
-              <ResultItem
-                key={item.questionId}
-                item={item}
-                index={mainIndex}
-              />
-            )
-          })}
+          {orderedHistory.map((item) => (
+            <ResultItem key={item.questionId} item={item} />
+          ))}
         </div>
       </div>
     </div>

--- a/src/main/java/wlsh/project/intervai/answer/application/AnswerService.java
+++ b/src/main/java/wlsh/project/intervai/answer/application/AnswerService.java
@@ -47,7 +47,12 @@ public class AnswerService {
         boolean withinLimit = session.getFollowUpCount() < interview.getMaxFollowUpCount();
 
         if (hasFollowUp && withinLimit) {
-            questionManager.createFollowUp(answer.getInterviewId(), answer.getSessionId(), followUpQuestion);
+            questionManager.createFollowUp(
+                    answer.getInterviewId(),
+                    answer.getSessionId(),
+                    answer.getQuestionId(),
+                    followUpQuestion
+            );
             interviewSessionManager.addFollowUpCount(session.getId());
         } else {
             interviewSessionManager.advanceToNext(session.getId());

--- a/src/main/java/wlsh/project/intervai/common/DevInitializer.java
+++ b/src/main/java/wlsh/project/intervai/common/DevInitializer.java
@@ -1,4 +1,0 @@
-package wlsh.project.intervai.common;
-
-public class DevInitializer {
-}

--- a/src/main/java/wlsh/project/intervai/common/DevInitializer.java
+++ b/src/main/java/wlsh/project/intervai/common/DevInitializer.java
@@ -1,0 +1,4 @@
+package wlsh.project.intervai.common;
+
+public class DevInitializer {
+}

--- a/src/main/java/wlsh/project/intervai/question/application/QuestionFinder.java
+++ b/src/main/java/wlsh/project/intervai/question/application/QuestionFinder.java
@@ -23,7 +23,7 @@ public class QuestionFinder {
     }
 
     public NextQuestionResult findCurrent(Long sessionId, int currentMainQuestionIdx,
-                                          int followUpCount, int totalQuestionCount) {
+                                          int followUpCount, int totalQuestionCount, int maxFollowUpCount) {
         if (followUpCount == 0 && currentMainQuestionIdx >= totalQuestionCount) {
             throw new CustomException(ErrorCode.ALL_QUESTIONS_ANSWERED);
         }
@@ -31,8 +31,16 @@ public class QuestionFinder {
                 ? findLatestFollowUp(sessionId)
                 : findMainQuestion(sessionId, currentMainQuestionIdx);
 
-        boolean hasNext = currentMainQuestionIdx < totalQuestionCount - 1;
+        boolean hasNext = hasNextQuestion(currentMainQuestionIdx, followUpCount, totalQuestionCount, maxFollowUpCount);
         return new NextQuestionResult(question, hasNext);
+    }
+
+    private boolean hasNextQuestion(int currentMainQuestionIdx, int followUpCount, int totalQuestionCount, int maxFollowUpCount) {
+        boolean hasRemainingMainQuestion = currentMainQuestionIdx < totalQuestionCount - 1;
+        if (hasRemainingMainQuestion) {
+            return true;
+        }
+        return followUpCount < maxFollowUpCount;
     }
 
     private Question findLatestFollowUp(Long sessionId) {

--- a/src/main/java/wlsh/project/intervai/question/application/QuestionManager.java
+++ b/src/main/java/wlsh/project/intervai/question/application/QuestionManager.java
@@ -26,11 +26,11 @@ public class QuestionManager {
     }
 
     @Transactional
-    public Optional<Question> createFollowUp(Long interviewId, Long sessionId, String content) {
+    public Optional<Question> createFollowUp(Long interviewId, Long sessionId, Long parentQuestionId, String content) {
         if (content == null || content.isBlank()) {
             return Optional.empty();
         }
-        Question question = Question.create(interviewId, sessionId, content, QuestionType.FOLLOW_UP, -1);
+        Question question = Question.createFollowUp(interviewId, sessionId, parentQuestionId, content);
         QuestionEntity entity = questionRepository.save(QuestionEntity.from(question));
         return Optional.of(entity.toDomain());
     }

--- a/src/main/java/wlsh/project/intervai/question/application/QuestionService.java
+++ b/src/main/java/wlsh/project/intervai/question/application/QuestionService.java
@@ -38,7 +38,8 @@ public class QuestionService {
                 session.getId(),
                 session.getCurrentMainQuestionIdx(),
                 session.getFollowUpCount(),
-                interview.getQuestionCount()
+                interview.getQuestionCount(),
+                interview.getMaxFollowUpCount()
         );
     }
 

--- a/src/main/java/wlsh/project/intervai/question/domain/Question.java
+++ b/src/main/java/wlsh/project/intervai/question/domain/Question.java
@@ -8,28 +8,40 @@ public class Question {
     private final Long id;
     private final Long interviewId;
     private final Long sessionId;
+    private final Long parentQuestionId;
     private final String content;
     private final QuestionType questionType;
     private final int questionIndex;
 
     private Question(Long id, Long interviewId, Long sessionId,
-                     String content, QuestionType questionType, int questionIndex) {
+                     Long parentQuestionId, String content, QuestionType questionType, int questionIndex) {
         this.id = id;
         this.interviewId = interviewId;
         this.sessionId = sessionId;
+        this.parentQuestionId = parentQuestionId;
         this.content = content;
         this.questionType = questionType;
         this.questionIndex = questionIndex;
     }
 
+    public static Question createFollowUp(Long interviewId, Long sessionId,
+                                          Long parentQuestionId, String content) {
+        return new Question(null, interviewId, sessionId, parentQuestionId, content, QuestionType.FOLLOW_UP, -1);
+    }
+
     public static Question create(Long interviewId, Long sessionId,
-                                   String content, QuestionType questionType, int questionIndex) {
-        return new Question(null, interviewId, sessionId, content, questionType, questionIndex);
+                                  String content, QuestionType questionType, int questionIndex) {
+        return new Question(null, interviewId, sessionId, null, content, questionType, questionIndex);
     }
 
     public static Question of(Long id, Long interviewId, Long sessionId,
-                                String content, QuestionType questionType, int questionIndex) {
-        return new Question(id, interviewId, sessionId, content, questionType, questionIndex);
+                              Long parentQuestionId, String content, QuestionType questionType, int questionIndex) {
+        return new Question(id, interviewId, sessionId, parentQuestionId, content, questionType, questionIndex);
+    }
+
+    public static Question of(Long id, Long interviewId, Long sessionId,
+                              String content, QuestionType questionType, int questionIndex) {
+        return of(id, interviewId, sessionId, null, content, questionType, questionIndex);
     }
 
     public boolean isFollowUp() {

--- a/src/main/java/wlsh/project/intervai/question/infra/QuestionEntity.java
+++ b/src/main/java/wlsh/project/intervai/question/infra/QuestionEntity.java
@@ -32,6 +32,8 @@ public class QuestionEntity extends BaseEntity {
     @Column(nullable = false)
     private Long sessionId;
 
+    private Long parentQuestionId;
+
     @Lob
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
@@ -43,10 +45,11 @@ public class QuestionEntity extends BaseEntity {
     @Column(nullable = false)
     private int questionIndex;
 
-    private QuestionEntity(Long interviewId, Long sessionId,
+    private QuestionEntity(Long interviewId, Long sessionId, Long parentQuestionId,
                            String content, QuestionType questionType, int questionIndex) {
         this.interviewId = interviewId;
         this.sessionId = sessionId;
+        this.parentQuestionId = parentQuestionId;
         this.content = content;
         this.questionType = questionType;
         this.questionIndex = questionIndex;
@@ -54,16 +57,17 @@ public class QuestionEntity extends BaseEntity {
 
     public static QuestionEntity from(Question question) {
         return new QuestionEntity(question.getInterviewId(),
-                question.getSessionId(), question.getContent(), question.getQuestionType(),
+                question.getSessionId(), question.getParentQuestionId(),
+                question.getContent(), question.getQuestionType(),
                 question.getQuestionIndex());
     }
 
-    public static QuestionEntity createFollowUp(Long interviewId, Long sessionId,
+    public static QuestionEntity createFollowUp(Long interviewId, Long sessionId, Long parentQuestionId,
                                                 String content) {
-        return new QuestionEntity(interviewId, sessionId, content, QuestionType.FOLLOW_UP, -1);
+        return new QuestionEntity(interviewId, sessionId, parentQuestionId, content, QuestionType.FOLLOW_UP, -1);
     }
 
     public Question toDomain() {
-        return Question.of(id, interviewId, sessionId, content, questionType, questionIndex);
+        return Question.of(id, interviewId, sessionId, parentQuestionId, content, questionType, questionIndex);
     }
 }

--- a/src/main/java/wlsh/project/intervai/session/application/SessionHistoryFinder.java
+++ b/src/main/java/wlsh/project/intervai/session/application/SessionHistoryFinder.java
@@ -13,9 +13,6 @@ import wlsh.project.intervai.session.infra.InterviewSessionRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -44,86 +41,9 @@ public class SessionHistoryFinder {
                         (existing, duplicate) -> existing
                 ));
 
-        List<SessionHistory> histories = sessionQuestions.stream()
+        return sessionQuestions.stream()
                 .map(sessionHistoryDto ->
                         SessionHistory.createSessionHistory(sessionHistoryDto, feedbacks.get(sessionHistoryDto.getAnswerId())))
                 .toList();
-        return sortByConversationFlow(histories);
-    }
-
-    private List<SessionHistory> sortByConversationFlow(List<SessionHistory> histories) {
-        List<SessionHistory> answered = histories.stream()
-                .filter(history -> history.answerId() != null)
-                .sorted(Comparator.comparing(SessionHistory::answerId))
-                .toList();
-
-        List<SessionHistory> unanswered = sortUnansweredByStructure(histories.stream()
-                .filter(history -> history.answerId() == null)
-                .toList());
-
-        List<SessionHistory> ordered = new ArrayList<>(answered.size() + unanswered.size());
-        ordered.addAll(answered);
-        ordered.addAll(unanswered);
-        return ordered;
-    }
-
-    private List<SessionHistory> sortUnansweredByStructure(List<SessionHistory> unanswered) {
-        if (unanswered.isEmpty()) {
-            return List.of();
-        }
-
-        Set<Long> unansweredQuestionIds = unanswered.stream()
-                .map(SessionHistory::questionId)
-                .collect(Collectors.toSet());
-
-        Map<Long, List<SessionHistory>> childrenByParentId = unanswered.stream()
-                .filter(history -> history.parentQuestionId() != null
-                        && unansweredQuestionIds.contains(history.parentQuestionId()))
-                .collect(Collectors.groupingBy(SessionHistory::parentQuestionId));
-
-        childrenByParentId.values()
-                .forEach(children -> children.sort(Comparator.comparing(SessionHistory::questionId)));
-
-        List<SessionHistory> roots = unanswered.stream()
-                .filter(history -> history.parentQuestionId() == null
-                        || !unansweredQuestionIds.contains(history.parentQuestionId()))
-                .sorted(Comparator
-                        .comparingInt((SessionHistory history) -> history.questionType() == QuestionType.QUESTION ? 0 : 1)
-                        .thenComparing(history -> history.questionType() == QuestionType.QUESTION
-                                ? history.questionIndex()
-                                : Integer.MAX_VALUE)
-                        .thenComparing(SessionHistory::questionId))
-                .toList();
-
-        List<SessionHistory> ordered = new ArrayList<>(unanswered.size());
-        Set<Long> visitedQuestionIds = new java.util.HashSet<>();
-        for (SessionHistory root : roots) {
-            appendDepthFirst(root, childrenByParentId, ordered, visitedQuestionIds);
-        }
-
-        Set<Long> orderedQuestionIds = ordered.stream()
-                .map(SessionHistory::questionId)
-                .collect(Collectors.toSet());
-        unanswered.stream()
-                .filter(history -> !orderedQuestionIds.contains(history.questionId()))
-                .sorted(Comparator.comparing(SessionHistory::questionId))
-                .forEach(ordered::add);
-
-        return ordered;
-    }
-
-    private void appendDepthFirst(
-            SessionHistory current,
-            Map<Long, List<SessionHistory>> childrenByParentId,
-            List<SessionHistory> ordered,
-            Set<Long> visitedQuestionIds
-    ) {
-        if (!visitedQuestionIds.add(current.questionId())) {
-            return;
-        }
-        ordered.add(current);
-        for (SessionHistory child : childrenByParentId.getOrDefault(current.questionId(), List.of())) {
-            appendDepthFirst(child, childrenByParentId, ordered, visitedQuestionIds);
-        }
     }
 }

--- a/src/main/java/wlsh/project/intervai/session/application/SessionHistoryFinder.java
+++ b/src/main/java/wlsh/project/intervai/session/application/SessionHistoryFinder.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import wlsh.project.intervai.common.entity.EntityStatus;
 import wlsh.project.intervai.feedback.infra.FeedbackEntity;
 import wlsh.project.intervai.feedback.infra.FeedbackRepository;
+import wlsh.project.intervai.question.domain.QuestionType;
 import wlsh.project.intervai.session.application.dto.SessionHistoryDto;
 import wlsh.project.intervai.session.domain.SessionHistory;
 import wlsh.project.intervai.session.infra.InterviewSessionRepository;
@@ -12,6 +13,8 @@ import wlsh.project.intervai.session.infra.InterviewSessionRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -40,9 +43,62 @@ public class SessionHistoryFinder {
                         (existing, duplicate) -> existing
                 ));
 
-        return sessionQuestions.stream()
+        List<SessionHistory> histories = sessionQuestions.stream()
                 .map(sessionHistoryDto ->
                         SessionHistory.createSessionHistory(sessionHistoryDto, feedbacks.get(sessionHistoryDto.getAnswerId())))
                 .toList();
+        return sortByConversationFlow(histories);
+    }
+
+    private List<SessionHistory> sortByConversationFlow(List<SessionHistory> histories) {
+        List<SessionHistory> answered = histories.stream()
+                .filter(history -> history.answerId() != null)
+                .sorted(Comparator.comparing(SessionHistory::answerId))
+                .toList();
+
+        List<SessionHistory> unanswered = sortUnansweredByStructure(histories.stream()
+                .filter(history -> history.answerId() == null)
+                .toList());
+
+        List<SessionHistory> ordered = new ArrayList<>(answered.size() + unanswered.size());
+        ordered.addAll(answered);
+        ordered.addAll(unanswered);
+        return ordered;
+    }
+
+    private List<SessionHistory> sortUnansweredByStructure(List<SessionHistory> unanswered) {
+        Map<Long, List<SessionHistory>> childrenByParentId = unanswered.stream()
+                .filter(history -> history.parentQuestionId() != null)
+                .collect(Collectors.groupingBy(SessionHistory::parentQuestionId));
+
+        childrenByParentId.values()
+                .forEach(children -> children.sort(Comparator.comparing(SessionHistory::questionId)));
+
+        List<SessionHistory> roots = unanswered.stream()
+                .filter(history -> history.parentQuestionId() == null)
+                .sorted(Comparator
+                        .comparingInt((SessionHistory history) -> history.questionType() == QuestionType.QUESTION ? 0 : 1)
+                        .thenComparing(history -> history.questionType() == QuestionType.QUESTION
+                                ? history.questionIndex()
+                                : Integer.MAX_VALUE)
+                        .thenComparing(SessionHistory::questionId))
+                .toList();
+
+        List<SessionHistory> ordered = new ArrayList<>(unanswered.size());
+        for (SessionHistory root : roots) {
+            appendDepthFirst(root, childrenByParentId, ordered);
+        }
+        return ordered;
+    }
+
+    private void appendDepthFirst(
+            SessionHistory current,
+            Map<Long, List<SessionHistory>> childrenByParentId,
+            List<SessionHistory> ordered
+    ) {
+        ordered.add(current);
+        for (SessionHistory child : childrenByParentId.getOrDefault(current.questionId(), List.of())) {
+            appendDepthFirst(child, childrenByParentId, ordered);
+        }
     }
 }

--- a/src/main/java/wlsh/project/intervai/session/application/SessionHistoryFinder.java
+++ b/src/main/java/wlsh/project/intervai/session/application/SessionHistoryFinder.java
@@ -96,8 +96,9 @@ public class SessionHistoryFinder {
                 .toList();
 
         List<SessionHistory> ordered = new ArrayList<>(unanswered.size());
+        Set<Long> visitedQuestionIds = new java.util.HashSet<>();
         for (SessionHistory root : roots) {
-            appendDepthFirst(root, childrenByParentId, ordered);
+            appendDepthFirst(root, childrenByParentId, ordered, visitedQuestionIds);
         }
 
         Set<Long> orderedQuestionIds = ordered.stream()
@@ -114,11 +115,15 @@ public class SessionHistoryFinder {
     private void appendDepthFirst(
             SessionHistory current,
             Map<Long, List<SessionHistory>> childrenByParentId,
-            List<SessionHistory> ordered
+            List<SessionHistory> ordered,
+            Set<Long> visitedQuestionIds
     ) {
+        if (!visitedQuestionIds.add(current.questionId())) {
+            return;
+        }
         ordered.add(current);
         for (SessionHistory child : childrenByParentId.getOrDefault(current.questionId(), List.of())) {
-            appendDepthFirst(child, childrenByParentId, ordered);
+            appendDepthFirst(child, childrenByParentId, ordered, visitedQuestionIds);
         }
     }
 }

--- a/src/main/java/wlsh/project/intervai/session/application/SessionHistoryFinder.java
+++ b/src/main/java/wlsh/project/intervai/session/application/SessionHistoryFinder.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -67,15 +68,25 @@ public class SessionHistoryFinder {
     }
 
     private List<SessionHistory> sortUnansweredByStructure(List<SessionHistory> unanswered) {
+        if (unanswered.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> unansweredQuestionIds = unanswered.stream()
+                .map(SessionHistory::questionId)
+                .collect(Collectors.toSet());
+
         Map<Long, List<SessionHistory>> childrenByParentId = unanswered.stream()
-                .filter(history -> history.parentQuestionId() != null)
+                .filter(history -> history.parentQuestionId() != null
+                        && unansweredQuestionIds.contains(history.parentQuestionId()))
                 .collect(Collectors.groupingBy(SessionHistory::parentQuestionId));
 
         childrenByParentId.values()
                 .forEach(children -> children.sort(Comparator.comparing(SessionHistory::questionId)));
 
         List<SessionHistory> roots = unanswered.stream()
-                .filter(history -> history.parentQuestionId() == null)
+                .filter(history -> history.parentQuestionId() == null
+                        || !unansweredQuestionIds.contains(history.parentQuestionId()))
                 .sorted(Comparator
                         .comparingInt((SessionHistory history) -> history.questionType() == QuestionType.QUESTION ? 0 : 1)
                         .thenComparing(history -> history.questionType() == QuestionType.QUESTION
@@ -88,6 +99,15 @@ public class SessionHistoryFinder {
         for (SessionHistory root : roots) {
             appendDepthFirst(root, childrenByParentId, ordered);
         }
+
+        Set<Long> orderedQuestionIds = ordered.stream()
+                .map(SessionHistory::questionId)
+                .collect(Collectors.toSet());
+        unanswered.stream()
+                .filter(history -> !orderedQuestionIds.contains(history.questionId()))
+                .sorted(Comparator.comparing(SessionHistory::questionId))
+                .forEach(ordered::add);
+
         return ordered;
     }
 

--- a/src/main/java/wlsh/project/intervai/session/application/dto/SessionHistoryDto.java
+++ b/src/main/java/wlsh/project/intervai/session/application/dto/SessionHistoryDto.java
@@ -4,6 +4,7 @@ import wlsh.project.intervai.question.domain.QuestionType;
 
 public interface SessionHistoryDto {
     Long getQuestionId();
+    Long getParentQuestionId();
     Long getAnswerId();
     QuestionType getQuestionType();
     Integer getQuestionIndex();

--- a/src/main/java/wlsh/project/intervai/session/domain/SessionHistory.java
+++ b/src/main/java/wlsh/project/intervai/session/domain/SessionHistory.java
@@ -7,6 +7,7 @@ import wlsh.project.intervai.session.application.dto.SessionHistoryDto;
 
 public record SessionHistory(
         Long questionId,
+        Long parentQuestionId,
         Long answerId,
         String questionContent,
         String answerContent,
@@ -18,6 +19,7 @@ public record SessionHistory(
     public static SessionHistory createSessionHistory(SessionHistoryDto sessionHistoryDto, @Nullable FeedbackEntity feedback) {
         return new SessionHistory(
                 sessionHistoryDto.getQuestionId(),
+                sessionHistoryDto.getParentQuestionId(),
                 sessionHistoryDto.getAnswerId(),
                 sessionHistoryDto.getQuestionContent(),
                 sessionHistoryDto.getAnswerContent(),

--- a/src/main/java/wlsh/project/intervai/session/infra/InterviewSessionRepository.java
+++ b/src/main/java/wlsh/project/intervai/session/infra/InterviewSessionRepository.java
@@ -17,12 +17,12 @@ public interface InterviewSessionRepository extends JpaRepository<InterviewSessi
     List<InterviewSessionEntity> findByInterviewIdInAndStatus(List<Long> interviewIds, EntityStatus status);
 
     @Query("""
-            select q.id as questionId, q.content as questionContent,
+            select q.id as questionId, q.parentQuestionId as parentQuestionId, q.content as questionContent,
                    q.questionType as questionType, q.questionIndex as questionIndex,
                    a.id as answerId, a.content as answerContent
             from QuestionEntity q left join AnswerEntity a on q.id = a.questionId and a.status = :status
             where q.interviewId = :interviewId and q.status = :status
-            order by q.id asc
+            order by q.questionIndex asc, q.id asc
             """)
     List<SessionHistoryDto> findSessionHistoryByInterviewId(@Param("interviewId") Long interviewId, @Param("status") EntityStatus status);
 }

--- a/src/main/java/wlsh/project/intervai/session/infra/InterviewSessionRepository.java
+++ b/src/main/java/wlsh/project/intervai/session/infra/InterviewSessionRepository.java
@@ -22,7 +22,7 @@ public interface InterviewSessionRepository extends JpaRepository<InterviewSessi
                    a.id as answerId, a.content as answerContent
             from QuestionEntity q left join AnswerEntity a on q.id = a.questionId and a.status = :status
             where q.interviewId = :interviewId and q.status = :status
-            order by q.questionIndex asc, q.id asc
+            order by q.id asc
             """)
     List<SessionHistoryDto> findSessionHistoryByInterviewId(@Param("interviewId") Long interviewId, @Param("status") EntityStatus status);
 }

--- a/src/main/java/wlsh/project/intervai/session/presentation/dto/SessionHistoryResponse.java
+++ b/src/main/java/wlsh/project/intervai/session/presentation/dto/SessionHistoryResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public record SessionHistoryResponse(
         Long questionId,
+        Long parentQuestionId,
         Long answerId,
         String questionContent,
         String answerContent,
@@ -17,6 +18,7 @@ public record SessionHistoryResponse(
     public static SessionHistoryResponse from(SessionHistory history) {
         return new SessionHistoryResponse(
                 history.questionId(),
+                history.parentQuestionId(),
                 history.answerId(),
                 history.questionContent(),
                 history.answerContent(),

--- a/src/test/java/wlsh/project/intervai/common/config/EmbeddedRedisConfig.java
+++ b/src/test/java/wlsh/project/intervai/common/config/EmbeddedRedisConfig.java
@@ -1,9 +1,9 @@
 package wlsh.project.intervai.common.config;
 
 import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import redis.embedded.RedisServer;
@@ -12,19 +12,45 @@ import redis.embedded.RedisServer;
 @Profile("local")
 public class EmbeddedRedisConfig {
 
-    private final RedisServer redisServer;
+    private static final Object LOCK = new Object();
+    private static final AtomicBoolean STARTED = new AtomicBoolean(false);
+    private static final int PORT = findAvailablePort();
+    private static RedisServer redisServer;
 
-    public EmbeddedRedisConfig(@Value("${spring.data.redis.port}") int port) throws IOException {
-        this.redisServer = new RedisServer(port);
+    static {
+        System.setProperty("spring.data.redis.port", String.valueOf(PORT));
     }
 
     @PostConstruct
     public void start() throws IOException {
-        redisServer.start();
+        synchronized (LOCK) {
+            if (STARTED.get()) {
+                return;
+            }
+
+            redisServer = new RedisServer(PORT);
+            redisServer.start();
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                synchronized (LOCK) {
+                    if (redisServer != null) {
+                        try {
+                            redisServer.stop();
+                        } catch (IOException ignored) {
+                        }
+                    }
+                }
+            }));
+            STARTED.set(true);
+        }
+
     }
 
-    @PreDestroy
-    public void stop() throws IOException {
-        redisServer.stop();
+    private static int findAvailablePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to allocate Redis port for tests", e);
+        }
     }
 }

--- a/src/test/java/wlsh/project/intervai/question/application/QuestionFinderTest.java
+++ b/src/test/java/wlsh/project/intervai/question/application/QuestionFinderTest.java
@@ -49,7 +49,7 @@ class QuestionFinderTest extends IntegrationTest {
         Question question = questionManager.create(interview.getId(), session.getId(), "본 질문 내용", QuestionType.QUESTION, 0);
 
         // when
-        NextQuestionResult result = questionFinder.findCurrent(session.getId(), 0, 0, 5);
+        NextQuestionResult result = questionFinder.findCurrent(session.getId(), 0, 0, 5, interview.getMaxFollowUpCount());
 
         // then
         assertThat(result.question().getId()).isEqualTo(question.getId());
@@ -68,7 +68,7 @@ class QuestionFinderTest extends IntegrationTest {
         questionManager.createFollowUp(interview.getId(), session.getId(), null, "꼬리 질문 내용");
 
         // when
-        NextQuestionResult result = questionFinder.findCurrent(session.getId(), 0, 1, 5);
+        NextQuestionResult result = questionFinder.findCurrent(session.getId(), 0, 1, 5, interview.getMaxFollowUpCount());
 
         // then
         assertThat(result.question().getQuestionType()).isEqualTo(QuestionType.FOLLOW_UP);
@@ -87,15 +87,15 @@ class QuestionFinderTest extends IntegrationTest {
         questionManager.createFollowUp(interview.getId(), session.getId(), null, "꼬리 질문 2");
 
         // when
-        NextQuestionResult result = questionFinder.findCurrent(session.getId(), 0, 2, 5);
+        NextQuestionResult result = questionFinder.findCurrent(session.getId(), 0, 2, 5, interview.getMaxFollowUpCount());
 
         // then
         assertThat(result.question().getContent()).isEqualTo("꼬리 질문 2");
     }
 
     @Test
-    @DisplayName("마지막 질문이면 hasNext가 false이다")
-    void findCurrentLastQuestionHasNoNext() {
+    @DisplayName("마지막 본 질문이어도 꼬리 질문 여지가 있으면 hasNext가 true이다")
+    void findCurrentLastMainQuestionStillHasNext() {
         // given
         Long userId = 1L;
         Interview interview = createInterview(userId, 3);
@@ -103,9 +103,34 @@ class QuestionFinderTest extends IntegrationTest {
         questionManager.create(interview.getId(), session.getId(), "마지막 질문", QuestionType.QUESTION, 2);
 
         // when
-        NextQuestionResult result = questionFinder.findCurrent(session.getId(), 2, 0, 3);
+        NextQuestionResult result = questionFinder.findCurrent(session.getId(), 2, 0, 3, interview.getMaxFollowUpCount());
 
         // then
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("마지막 질문의 마지막 꼬리 질문이면 hasNext가 false이다")
+    void findCurrentLastFollowUpHasNoNext() {
+        Long userId = 1L;
+        Interview interview = createInterview(userId, 3);
+        InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
+        Question mainQuestion = questionManager.create(interview.getId(), session.getId(), "마지막 질문", QuestionType.QUESTION, 2);
+        Question followUp1 = questionManager.createFollowUp(interview.getId(), session.getId(), mainQuestion.getId(), "꼬리 질문 1")
+                .orElseThrow();
+        Question followUp2 = questionManager.createFollowUp(interview.getId(), session.getId(), followUp1.getId(), "꼬리 질문 2")
+                .orElseThrow();
+        questionManager.createFollowUp(interview.getId(), session.getId(), followUp2.getId(), "꼬리 질문 3")
+                .orElseThrow();
+
+        NextQuestionResult result = questionFinder.findCurrent(
+                session.getId(),
+                2,
+                interview.getMaxFollowUpCount(),
+                3,
+                interview.getMaxFollowUpCount()
+        );
+
         assertThat(result.hasNext()).isFalse();
     }
 
@@ -118,7 +143,7 @@ class QuestionFinderTest extends IntegrationTest {
         InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
 
         // when & then
-        assertThatThrownBy(() -> questionFinder.findCurrent(session.getId(), 0, 0, 5))
+        assertThatThrownBy(() -> questionFinder.findCurrent(session.getId(), 0, 0, 5, interview.getMaxFollowUpCount()))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.QUESTION_NOT_FOUND.getMessage());
     }
@@ -132,7 +157,7 @@ class QuestionFinderTest extends IntegrationTest {
         InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
 
         // when & then
-        assertThatThrownBy(() -> questionFinder.findCurrent(session.getId(), 0, 1, 5))
+        assertThatThrownBy(() -> questionFinder.findCurrent(session.getId(), 0, 1, 5, interview.getMaxFollowUpCount()))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.QUESTION_NOT_FOUND.getMessage());
     }

--- a/src/test/java/wlsh/project/intervai/question/application/QuestionFinderTest.java
+++ b/src/test/java/wlsh/project/intervai/question/application/QuestionFinderTest.java
@@ -65,7 +65,7 @@ class QuestionFinderTest extends IntegrationTest {
         Interview interview = createInterview(userId, 5);
         InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
         questionManager.create(interview.getId(), session.getId(), "본 질문 내용", QuestionType.QUESTION, 0);
-        questionManager.createFollowUp(interview.getId(), session.getId(), "꼬리 질문 내용");
+        questionManager.createFollowUp(interview.getId(), session.getId(), null, "꼬리 질문 내용");
 
         // when
         NextQuestionResult result = questionFinder.findCurrent(session.getId(), 0, 1, 5);
@@ -83,8 +83,8 @@ class QuestionFinderTest extends IntegrationTest {
         Interview interview = createInterview(userId, 5);
         InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
         questionManager.create(interview.getId(), session.getId(), "본 질문", QuestionType.QUESTION, 0);
-        questionManager.createFollowUp(interview.getId(), session.getId(), "꼬리 질문 1");
-        questionManager.createFollowUp(interview.getId(), session.getId(), "꼬리 질문 2");
+        questionManager.createFollowUp(interview.getId(), session.getId(), null, "꼬리 질문 1");
+        questionManager.createFollowUp(interview.getId(), session.getId(), null, "꼬리 질문 2");
 
         // when
         NextQuestionResult result = questionFinder.findCurrent(session.getId(), 0, 2, 5);

--- a/src/test/java/wlsh/project/intervai/question/infra/QuestionGeneratorTest.java
+++ b/src/test/java/wlsh/project/intervai/question/infra/QuestionGeneratorTest.java
@@ -1,6 +1,7 @@
 package wlsh.project.intervai.question.infra;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.ollama.OllamaChatModel;
@@ -40,6 +41,7 @@ class QuestionGeneratorTest {
     }
 
     @Test
+    @Disabled
     void prompt() throws Exception {
         // given
         Interview interview = Interview.create(1L, new CreateInterviewCommand(

--- a/src/test/java/wlsh/project/intervai/question/infra/QuestionRepositoryTest.java
+++ b/src/test/java/wlsh/project/intervai/question/infra/QuestionRepositoryTest.java
@@ -66,6 +66,7 @@ class QuestionRepositoryTest extends IntegrationTest {
         assertThat(result).hasSize(2);
         assertThat(result).allMatch(dto -> dto.getAnswerId() != null);
         assertThat(result).allMatch(dto -> dto.getAnswerContent() != null);
+        assertThat(result).allMatch(dto -> dto.getParentQuestionId() == null);
     }
 
     @Test
@@ -121,6 +122,27 @@ class QuestionRepositoryTest extends IntegrationTest {
         // then
         assertThat(result).hasSize(1);
         assertThat(result.getFirst().getQuestionContent()).isEqualTo("면접1 질문");
+    }
+
+    @Test
+    @DisplayName("꼬리 질문은 부모 questionId를 함께 조회한다")
+    void findSessionHistory_followUpIncludesParentQuestionId() {
+        Long userId = 1L;
+        Interview interview = createInterview(userId);
+        InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
+
+        Question main = questionManager.create(interview.getId(), session.getId(), "질문1", QuestionType.QUESTION, 0);
+        Question followUp = questionManager.createFollowUp(interview.getId(), session.getId(), main.getId(), "꼬리질문1")
+                .orElseThrow();
+
+        List<SessionHistoryDto> result = interviewSessionRepository.findSessionHistoryByInterviewId(
+                interview.getId(), EntityStatus.ACTIVE);
+
+        SessionHistoryDto followUpHistory = result.stream()
+                .filter(dto -> dto.getQuestionId().equals(followUp.getId()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(followUpHistory.getParentQuestionId()).isEqualTo(main.getId());
     }
 
     private Interview createInterview(Long userId) {

--- a/src/test/java/wlsh/project/intervai/session/application/InterviewSessionServiceTest.java
+++ b/src/test/java/wlsh/project/intervai/session/application/InterviewSessionServiceTest.java
@@ -165,6 +165,33 @@ class InterviewSessionServiceTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("답변된 부모를 가진 미답변 꼬리 질문도 히스토리에서 누락되지 않는다")
+    void findSessionHistory_unansweredFollowUpWithAnsweredParent_isNotDropped() {
+        Long userId = 1L;
+        Interview interview = createInterview(userId);
+        InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
+
+        Question q1 = questionManager.create(interview.getId(), session.getId(), "질문1", QuestionType.QUESTION, 0);
+        Question q2 = questionManager.create(interview.getId(), session.getId(), "질문2", QuestionType.QUESTION, 1);
+        Question followUp = questionManager.createFollowUp(interview.getId(), session.getId(), q1.getId(), "꼬리질문1")
+                .orElseThrow();
+
+        saveAnswer(userId, interview.getId(), session.getId(), q1.getId(), "답변1");
+
+        List<SessionHistory> result = interviewSessionService.findSessionHistory(userId, interview.getId());
+
+        assertThat(result)
+                .extracting(SessionHistory::questionContent)
+                .containsExactly("질문1", "질문2", "꼬리질문1");
+
+        SessionHistory unansweredFollowUp = result.stream()
+                .filter(history -> history.questionId().equals(followUp.getId()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(unansweredFollowUp.answerId()).isNull();
+    }
+
+    @Test
     @DisplayName("타인의 면접 히스토리 조회 시 INTERVIEW_ACCESS_DENIED 예외가 발생한다")
     void findSessionHistory_otherUserInterview_throwsAccessDenied() {
         // given

--- a/src/test/java/wlsh/project/intervai/session/application/InterviewSessionServiceTest.java
+++ b/src/test/java/wlsh/project/intervai/session/application/InterviewSessionServiceTest.java
@@ -118,6 +118,53 @@ class InterviewSessionServiceTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("히스토리는 부모 질문 다음에 꼬리 질문이 이어지도록 정렬된다")
+    void findSessionHistory_ordersFollowUpsAfterParentQuestion() {
+        Long userId = 1L;
+        Interview interview = createInterview(userId);
+        InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
+
+        Question q1 = questionManager.create(interview.getId(), session.getId(), "질문1", QuestionType.QUESTION, 0);
+        Question q2 = questionManager.create(interview.getId(), session.getId(), "질문2", QuestionType.QUESTION, 1);
+        Question followUp1 = questionManager.createFollowUp(interview.getId(), session.getId(), q1.getId(), "꼬리질문1")
+                .orElseThrow();
+        questionManager.createFollowUp(interview.getId(), session.getId(), followUp1.getId(), "꼬리질문2")
+                .orElseThrow();
+
+        List<SessionHistory> result = interviewSessionService.findSessionHistory(userId, interview.getId());
+
+        assertThat(result)
+                .extracting(SessionHistory::questionContent)
+                .containsExactly("질문1", "꼬리질문1", "꼬리질문2", "질문2");
+    }
+
+    @Test
+    @DisplayName("부모 정보가 없어도 answerId 순서대로 대화 흐름을 복원한다")
+    void findSessionHistory_ordersByAnswerIdWhenParentIsMissing() {
+        Long userId = 1L;
+        Interview interview = createInterview(userId);
+        InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
+
+        Question q1 = questionManager.create(interview.getId(), session.getId(), "질문1", QuestionType.QUESTION, 0);
+        Question q2 = questionManager.create(interview.getId(), session.getId(), "질문2", QuestionType.QUESTION, 1);
+        Question followUp1 = questionManager.createFollowUp(interview.getId(), session.getId(), null, "꼬리질문1")
+                .orElseThrow();
+        Question followUp2 = questionManager.createFollowUp(interview.getId(), session.getId(), null, "꼬리질문2")
+                .orElseThrow();
+
+        saveAnswer(userId, interview.getId(), session.getId(), q1.getId(), "답변1");
+        saveAnswer(userId, interview.getId(), session.getId(), followUp1.getId(), "답변1-1");
+        saveAnswer(userId, interview.getId(), session.getId(), followUp2.getId(), "답변1-2");
+        saveAnswer(userId, interview.getId(), session.getId(), q2.getId(), "답변2");
+
+        List<SessionHistory> result = interviewSessionService.findSessionHistory(userId, interview.getId());
+
+        assertThat(result)
+                .extracting(SessionHistory::questionContent)
+                .containsExactly("질문1", "꼬리질문1", "꼬리질문2", "질문2");
+    }
+
+    @Test
     @DisplayName("타인의 면접 히스토리 조회 시 INTERVIEW_ACCESS_DENIED 예외가 발생한다")
     void findSessionHistory_otherUserInterview_throwsAccessDenied() {
         // given

--- a/src/test/java/wlsh/project/intervai/session/application/InterviewSessionServiceTest.java
+++ b/src/test/java/wlsh/project/intervai/session/application/InterviewSessionServiceTest.java
@@ -118,8 +118,8 @@ class InterviewSessionServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("히스토리는 부모 질문 다음에 꼬리 질문이 이어지도록 정렬된다")
-    void findSessionHistory_ordersFollowUpsAfterParentQuestion() {
+    @DisplayName("히스토리는 질문 생성 순서대로 반환된다")
+    void findSessionHistory_returnsQuestionsInCreationOrder() {
         Long userId = 1L;
         Interview interview = createInterview(userId);
         InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
@@ -135,12 +135,12 @@ class InterviewSessionServiceTest extends IntegrationTest {
 
         assertThat(result)
                 .extracting(SessionHistory::questionContent)
-                .containsExactly("질문1", "꼬리질문1", "꼬리질문2", "질문2");
+                .containsExactly("질문1", "질문2", "꼬리질문1", "꼬리질문2");
     }
 
     @Test
-    @DisplayName("부모 정보가 없어도 answerId 순서대로 대화 흐름을 복원한다")
-    void findSessionHistory_ordersByAnswerIdWhenParentIsMissing() {
+    @DisplayName("부모 정보가 없어도 히스토리는 생성 순서를 유지한다")
+    void findSessionHistory_keepsCreationOrderWhenParentIsMissing() {
         Long userId = 1L;
         Interview interview = createInterview(userId);
         InterviewSession session = interviewSessionManager.create(interview.getId(), userId);
@@ -161,7 +161,7 @@ class InterviewSessionServiceTest extends IntegrationTest {
 
         assertThat(result)
                 .extracting(SessionHistory::questionContent)
-                .containsExactly("질문1", "꼬리질문1", "꼬리질문2", "질문2");
+                .containsExactly("질문1", "질문2", "꼬리질문1", "꼬리질문2");
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6379
+      port: 6378
   datasource:
     url: jdbc:h2:mem:intervai
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
## Summary
- store follow-up parent question information in session history models and responses
- return session history in actual conversation order, using answer sequence for legacy rows without parent links
- align frontend history restoration/result rendering with grouped follow-up ordering

## Testing
- ./gradlew test --tests wlsh.project.intervai.session.application.InterviewSessionServiceTest
- cd front && npm run build