### PR TITLE
feat: 히스토리 페이지 구현 (#21)

### DIFF
--- a/front/PLAN.md
+++ b/front/PLAN.md
@@ -1,4 +1,226 @@
-# 면접 진행(채팅) 화면 구현 플랜
+# 히스토리 페이지 구현 계획 — fe/feat/history (Issue #21)
+
+## 브랜치
+`fe/feat/history`
+
+## 요구사항
+
+- 면접 히스토리 목록 조회 (서버 페이지네이션: page, size)
+- 인터뷰 타입 필터: CS / PORTFOLIO / ALL (서버 파라미터)
+- 세션 상태 필터: COMPLETED / IN_PROGRESS (서버 파라미터)
+- 키워드 검색 (클라이언트 사이드 — 백엔드 파라미터 미제공)
+- 히스토리 카드: 인터뷰 타입 뱃지, 난이도 뱃지, 날짜, 문항 수, AI 스코어, 상태 뱃지
+- AI SCORE: 백엔드 미지원 → "-- /100" 고정 표시 (향후 별도 이슈)
+- 완료 세션: "결과 보기 >" 버튼 → `/interviews/:id/result` 이동
+- 진행중 세션: "이어하기" 버튼 (disabled, 별도 이슈)
+- 삭제: 모든 세션 삭제 가능 (DELETE /api/interviews/:id, 확인 다이얼로그 포함)
+- 페이지네이션 UI (◁ 1 2 3 ... N ▷)
+
+## 디자인 (history.png 기준)
+
+레이아웃:
+- 상단: "면접 히스토리" 타이틀 + 설명 텍스트
+- 검색/필터 바: 검색 Input + 인터뷰 타입 Select + 상태 Select
+- 카드 목록
+- 하단 페이지네이션
+
+색상 토큰:
+- `CS` 뱃지: `bg-blue-100 text-blue-700` (레이블: "CS INTERVIEW")
+- `PORTFOLIO` 뱃지: `bg-purple-100 text-purple-700` (레이블: "PORTFOLIO")
+- `ALL` 뱃지: `bg-green-100 text-green-700` (레이블: "ALL ROUNDER")
+- COMPLETED 상태: `text-green-600` (● 완료)
+- IN_PROGRESS 상태: `text-orange-500` (● 진행중)
+- "이어하기" 버튼: `bg-blue-600 text-white` (disabled)
+- "결과 보기 >" 버튼: shadcn `variant="outline"`
+- 삭제 아이콘: `text-gray-400 hover:text-red-500`
+
+난이도 뱃지: ENTRY / JUNIOR / SENIOR
+
+## 현재 구현 상태
+
+- `front/src/shared/pages/HistoryPage.tsx` — 플레이스홀더만 존재
+- `front/src/app/router.tsx` — `/history` 라우트 이미 등록됨
+- `front/src/features/` — auth, dashboard, interview, profile 피처 존재
+- `front/src/shared/api/httpClient.ts` — axios 인스턴스 재사용
+- `front/src/shared/components/ui/` — shadcn/ui 프리미티브 재사용
+
+## 백엔드 API (docs/api.md)
+
+### GET /api/interviews
+- Query: `page` (default 0), `size` (default 10), `interviewType` (선택: CS/PORTFOLIO/ALL), `sessionStatus` (선택: IN_PROGRESS/COMPLETED)
+- Response: `{ content: InterviewSummary[], totalElements, totalPages, last }`
+- InterviewSummary: `{ id, interviewType, difficulty, questionCount, sessionStatus, createdAt }`
+
+### DELETE /api/interviews/{interviewId}
+- 204 No Content
+- 403: INTERVIEW_ACCESS_DENIED
+
+## 파일 목록
+
+| 파일 | 작업 | 설명 |
+|------|------|------|
+| `front/src/features/history/types/index.ts` | 생성 | 타입 정의 |
+| `front/src/shared/types/queryKeys.ts` | 수정 | history 키 그룹 추가 |
+| `front/src/features/history/api/historyApi.ts` | 생성 | API 함수 |
+| `front/src/features/history/hooks/useInterviewHistory.ts` | 생성 | useQuery 훅 |
+| `front/src/features/history/hooks/useDeleteInterview.ts` | 생성 | useMutation 훅 |
+| `front/src/features/history/utils/formatDate.ts` | 생성 | 날짜 포맷 유틸 |
+| `front/src/shared/components/ui/PaginationBar.tsx` | 생성 | 공유 페이지네이션 |
+| `front/src/features/history/components/InterviewHistoryCard.tsx` | 생성 | 히스토리 카드 |
+| `front/src/features/history/components/HistoryFilterBar.tsx` | 생성 | 검색+필터 바 |
+| `front/src/features/history/components/DeleteConfirmDialog.tsx` | 생성 | 삭제 확인 다이얼로그 |
+| `front/src/features/history/pages/HistoryPage.tsx` | 생성 | 히스토리 페이지 구현 |
+| `front/src/shared/pages/HistoryPage.tsx` | 수정 | features/history re-export로 교체 |
+
+## 개발 계획
+
+### Step 1: 타입 정의
+파일: `front/src/features/history/types/index.ts`
+
+```ts
+export type InterviewType = 'CS' | 'PORTFOLIO' | 'ALL';
+export type SessionStatus = 'COMPLETED' | 'IN_PROGRESS';
+export type Difficulty = 'ENTRY' | 'JUNIOR' | 'SENIOR';
+
+export interface InterviewSummary {
+  id: number;
+  interviewType: InterviewType;
+  difficulty: Difficulty;
+  questionCount: number;
+  sessionStatus: SessionStatus;
+  createdAt: string; // ISO 8601
+}
+
+export interface InterviewListResponse {
+  content: InterviewSummary[];
+  totalElements: number;
+  totalPages: number;
+  last: boolean;
+}
+
+export interface InterviewListParams {
+  page?: number;
+  size?: number;
+  interviewType?: InterviewType;
+  sessionStatus?: SessionStatus;
+}
+
+export interface HistoryFilterState {
+  keyword: string;
+  interviewType: InterviewType | '';
+  sessionStatus: SessionStatus | '';
+}
+```
+
+### Step 2: Query Key 등록
+파일: `front/src/shared/types/queryKeys.ts` (수정)
+
+기존 queryKeys 객체에 history 그룹 추가:
+```ts
+history: {
+  all: ['history'] as const,
+  list: (params?: InterviewListParams) => ['history', 'list', params] as const,
+},
+```
+
+### Step 3: API 클라이언트
+파일: `front/src/features/history/api/historyApi.ts`
+
+```ts
+import { httpClient } from '@/shared/api/httpClient';
+import type { InterviewListParams, InterviewListResponse } from '../types';
+
+export const getInterviewList = (params: InterviewListParams): Promise<InterviewListResponse> =>
+  httpClient.get('/api/interviews', { params }).then((res) => res.data);
+
+export const deleteInterview = (interviewId: number): Promise<void> =>
+  httpClient.delete(`/api/interviews/${interviewId}`).then(() => undefined);
+```
+
+### Step 4: TanStack Query 훅
+
+파일: `front/src/features/history/hooks/useInterviewHistory.ts`
+- `useQuery` + `placeholderData: (prev) => prev` (TanStack Query v5 방식)
+- queryKey: `queryKeys.history.list(params)`
+
+파일: `front/src/features/history/hooks/useDeleteInterview.ts`
+- `useMutation`
+- onSuccess: `queryClient.invalidateQueries({ queryKey: queryKeys.history.all })`
+
+### Step 5: UI 컴포넌트
+
+#### PaginationBar (공유)
+파일: `front/src/shared/components/ui/PaginationBar.tsx`
+- Props: `currentPage: number` (0-based), `totalPages: number`, `onPageChange: (page: number) => void`
+- 1-based 페이지 번호 표시, 최대 5개 + 말줄임표
+- 이전/다음 버튼 경계에서 disabled
+- shadcn/ui Button 재사용
+
+#### InterviewHistoryCard
+파일: `front/src/features/history/components/InterviewHistoryCard.tsx`
+- Props: `interview: InterviewSummary`, `onDelete: (id: number) => void`
+- 인터뷰 타입 뱃지 색상 매핑 (CS→blue, PORTFOLIO→purple, ALL→green)
+- 날짜: `createdAt` → `YYYY.MM.DD` 포맷
+- AI SCORE: 항상 "-- /100"
+- 상태 뱃지: COMPLETED="● 완료"(green), IN_PROGRESS="● 진행중"(orange)
+- 완료: "결과 보기 >" 버튼 → navigate('/interviews/{id}/result')
+- 진행중: "이어하기" 버튼 (disabled)
+- 삭제 아이콘 (lucide-react Trash2) → onDelete(id) — 모든 상태에 표시
+
+#### HistoryFilterBar
+파일: `front/src/features/history/components/HistoryFilterBar.tsx`
+- Props: `filters: HistoryFilterState`, `onFilterChange: (filters: HistoryFilterState) => void`
+- 검색 Input (placeholder: "면접 키워드 검색...")
+- 인터뷰 타입 Select: "전체 면접" / "CS INTERVIEW" / "PORTFOLIO" / "ALL ROUNDER"
+- 상태 Select: "전체 상태" / "완료" / "진행중"
+
+#### DeleteConfirmDialog
+파일: `front/src/features/history/components/DeleteConfirmDialog.tsx`
+- shadcn/ui Dialog 재사용
+- 확인: variant="destructive", isPending 시 "삭제 중..."
+
+### Step 6: 페이지 컴포넌트
+
+파일: `front/src/features/history/pages/HistoryPage.tsx`
+- `useSearchParams`로 page URL 파라미터 관리 (기본값 0)
+- 서버: interviewType, sessionStatus 필터 파라미터로 전달
+- 클라이언트: keyword로 content 배열 필터링
+- 로딩: Skeleton 카드 표시
+- 에러: 에러 메시지 표시
+- 빈 목록: "면접 기록이 없습니다." 안내
+- 삭제 플로우: 아이콘 → Dialog → 확인 → mutate → invalidate → Dialog 닫기
+- 필터 변경 시 page=0으로 리셋
+
+파일: `front/src/shared/pages/HistoryPage.tsx` (수정)
+```tsx
+export { default } from '@/features/history/pages/HistoryPage';
+```
+
+### Step 7: 검증
+```bash
+cd /tmp/intervai-fe/front && npm run typecheck
+cd /tmp/intervai-fe/front && npm run build
+```
+
+## 주의사항
+
+1. **InterviewType enum**: API는 `CS`, `PORTFOLIO`, `ALL` — `CS_INTERVIEW`, `ALL_ROUNDER` 아님
+2. **크로스 피처 임포트 금지**: features/history에서 다른 features 직접 임포트 불가
+3. **서버 상태 Zustand 저장 금지**: TanStack Query로만 관리
+4. **TanStack Query v5**: `keepPreviousData` 없음, `placeholderData: (prev) => prev`
+5. **AI SCORE 고정**: "-- /100" 하드코딩
+6. **"이어하기" 버튼**: disabled + cursor-not-allowed
+7. **삭제는 모든 상태 허용**: COMPLETED, IN_PROGRESS 모두 삭제 가능 (디자인 기준)
+8. **queryKeys.history** 타입 임포트: InterviewListParams를 queryKeys.ts에서 임포트할 때 순환 참조 주의 — 필요시 params를 unknown으로 타입 완화
+
+---
+
+# [구 플랜 — 면접 진행(채팅) 화면 구현 플랜]
+<!-- 아래는 이전 이슈(면접 세션 채팅 화면)의 플랜입니다. 참고용으로 유지합니다. -->
+
+## 요구사항 (구 플랜)
+
+- phase='chat' 진입 시 채팅 형식의 면접 진행 화면을 표시한다
 
 ## 요구사항
 

--- a/front/src/features/history/api/historyApi.ts
+++ b/front/src/features/history/api/historyApi.ts
@@ -1,0 +1,9 @@
+import { httpClient } from '@/shared/api/httpClient'
+import { API_PATHS } from '@/shared/api/constants'
+import type { InterviewListParams, InterviewListResponse } from '../types'
+
+export const getInterviewList = (params: InterviewListParams): Promise<InterviewListResponse> =>
+  httpClient.get<InterviewListResponse>(API_PATHS.interviews.list, { params }).then((res) => res.data)
+
+export const deleteInterview = (interviewId: number): Promise<void> =>
+  httpClient.delete(API_PATHS.interviews.delete(interviewId)).then(() => undefined)

--- a/front/src/features/history/components/DeleteConfirmDialog.tsx
+++ b/front/src/features/history/components/DeleteConfirmDialog.tsx
@@ -1,0 +1,39 @@
+interface Props {
+  open: boolean
+  onConfirm: () => void
+  onCancel: () => void
+  isPending: boolean
+}
+
+const DeleteConfirmDialog = ({ open, onConfirm, onCancel, isPending }: Props) => {
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-xl shadow-lg p-6 w-80 max-w-full">
+        <h2 className="text-base font-semibold text-[#131b2e] mb-3">면접 삭제</h2>
+        <p className="text-sm text-[#767586] mb-6">
+          삭제된 면접은 복구할 수 없습니다. 정말 삭제하시겠습니까?
+        </p>
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={onCancel}
+            disabled={isPending}
+            className="px-4 py-2 text-sm font-medium text-[#767586] border border-[#767586] rounded hover:bg-gray-50 transition-colors disabled:opacity-50"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isPending}
+            className="px-4 py-2 text-sm font-medium text-white bg-red-500 rounded hover:bg-red-600 transition-colors disabled:opacity-60"
+          >
+            {isPending ? '삭제 중...' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default DeleteConfirmDialog

--- a/front/src/features/history/components/HistoryFilterBar.tsx
+++ b/front/src/features/history/components/HistoryFilterBar.tsx
@@ -1,0 +1,78 @@
+import type { HistoryFilterState, InterviewType, SessionStatus } from '../types'
+
+interface Props {
+  filters: HistoryFilterState
+  onFilterChange: (filters: HistoryFilterState) => void
+}
+
+const INTERVIEW_TYPE_OPTIONS: { value: InterviewType | ''; label: string }[] = [
+  { value: '', label: '전체 면접' },
+  { value: 'CS', label: 'CS INTERVIEW' },
+  { value: 'PORTFOLIO', label: 'PORTFOLIO' },
+  { value: 'ALL', label: 'ALL ROUNDER' },
+]
+
+const SESSION_STATUS_OPTIONS: { value: SessionStatus | ''; label: string }[] = [
+  { value: '', label: '전체 상태' },
+  { value: 'COMPLETED', label: '완료' },
+  { value: 'IN_PROGRESS', label: '진행중' },
+]
+
+const HistoryFilterBar = ({ filters, onFilterChange }: Props) => {
+  return (
+    <div className="flex flex-col sm:flex-row gap-3">
+      <div className="relative flex-1">
+        <svg
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 w-4 h-4"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+        <input
+          type="text"
+          placeholder="면접 키워드 검색..."
+          value={filters.keyword}
+          onChange={(e) => onFilterChange({ ...filters, keyword: e.target.value })}
+          className="w-full pl-9 pr-4 py-2.5 border border-[#e8e8f0] rounded-lg text-sm text-gray-700 placeholder-gray-400 focus:outline-none focus:border-[#4648d4]"
+        />
+      </div>
+
+      <select
+        value={filters.interviewType}
+        onChange={(e) =>
+          onFilterChange({ ...filters, interviewType: e.target.value as InterviewType | '' })
+        }
+        className="px-3 py-2.5 border border-[#e8e8f0] rounded-lg text-sm text-gray-700 bg-white focus:outline-none focus:border-[#4648d4] cursor-pointer"
+      >
+        {INTERVIEW_TYPE_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      <select
+        value={filters.sessionStatus}
+        onChange={(e) =>
+          onFilterChange({ ...filters, sessionStatus: e.target.value as SessionStatus | '' })
+        }
+        className="px-3 py-2.5 border border-[#e8e8f0] rounded-lg text-sm text-gray-700 bg-white focus:outline-none focus:border-[#4648d4] cursor-pointer"
+      >
+        {SESSION_STATUS_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+export default HistoryFilterBar

--- a/front/src/features/history/components/InterviewHistoryCard.tsx
+++ b/front/src/features/history/components/InterviewHistoryCard.tsx
@@ -1,0 +1,89 @@
+import { useNavigate } from 'react-router-dom'
+import type { InterviewSummary } from '../types'
+import { formatHistoryDate } from '../utils/formatDate'
+
+const INTERVIEW_TYPE_LABELS: Record<string, string> = {
+  CS: 'CS INTERVIEW',
+  PORTFOLIO: 'PORTFOLIO',
+  ALL: 'ALL ROUNDER',
+}
+
+const INTERVIEW_TYPE_COLORS: Record<string, string> = {
+  CS: 'bg-blue-100 text-blue-700',
+  PORTFOLIO: 'bg-purple-100 text-purple-700',
+  ALL: 'bg-green-100 text-green-700',
+}
+
+interface Props {
+  interview: InterviewSummary
+  onDelete: (id: number) => void
+}
+
+const InterviewHistoryCard = ({ interview, onDelete }: Props) => {
+  const navigate = useNavigate()
+  const isCompleted = interview.sessionStatus === 'COMPLETED'
+
+  return (
+    <div className="bg-white rounded-xl border border-[#e8e8f0] p-5 flex flex-col gap-3">
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span
+            className={`text-xs font-semibold px-2 py-0.5 rounded ${INTERVIEW_TYPE_COLORS[interview.interviewType] ?? 'bg-gray-100 text-gray-700'}`}
+          >
+            {INTERVIEW_TYPE_LABELS[interview.interviewType] ?? interview.interviewType}
+          </span>
+          <span className="text-xs font-semibold px-2 py-0.5 rounded bg-gray-100 text-gray-600">
+            {interview.difficulty}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="text-right">
+            <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wide">AI SCORE</p>
+            <p className="text-lg font-bold text-gray-300">--<span className="text-xs font-normal text-gray-400">/100</span></p>
+          </div>
+          <button
+            onClick={() => onDelete(interview.id)}
+            className="ml-1 text-gray-300 hover:text-red-400 transition-colors"
+            aria-label="면접 삭제"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+              <path d="M10 11v6M14 11v6" />
+              <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <p className="text-sm text-gray-500">
+          {formatHistoryDate(interview.createdAt)} · {interview.questionCount}문항
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className={`text-sm font-medium ${isCompleted ? 'text-green-600' : 'text-orange-500'}`}>
+          ● {isCompleted ? '완료' : '진행중'}
+        </span>
+        {isCompleted ? (
+          <button
+            onClick={() => navigate(`/interviews/${interview.id}/result`)}
+            className="text-sm font-medium text-gray-600 border border-gray-300 rounded px-3 py-1.5 hover:bg-gray-50 transition-colors"
+          >
+            결과 보기 &gt;
+          </button>
+        ) : (
+          <button
+            disabled
+            className="text-sm font-medium text-white bg-blue-600 rounded px-3 py-1.5 opacity-60 cursor-not-allowed"
+          >
+            이어하기
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default InterviewHistoryCard

--- a/front/src/features/history/hooks/useDeleteInterview.ts
+++ b/front/src/features/history/hooks/useDeleteInterview.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { queryKeys } from '@/shared/types/queryKeys'
+import { deleteInterview } from '../api/historyApi'
+
+const useDeleteInterview = (onSuccess?: () => void) => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (interviewId: number) => deleteInterview(interviewId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.interviews.all })
+      onSuccess?.()
+    },
+  })
+}
+
+export default useDeleteInterview

--- a/front/src/features/history/hooks/useInterviewHistory.ts
+++ b/front/src/features/history/hooks/useInterviewHistory.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { queryKeys } from '@/shared/types/queryKeys'
+import { getInterviewList } from '../api/historyApi'
+import type { InterviewListParams } from '../types'
+
+const useInterviewHistory = (params: InterviewListParams) => {
+  return useQuery({
+    queryKey: queryKeys.interviews.list(params as Record<string, unknown>),
+    queryFn: () => getInterviewList(params),
+    placeholderData: (prev) => prev,
+  })
+}
+
+export default useInterviewHistory

--- a/front/src/features/history/pages/HistoryPage.tsx
+++ b/front/src/features/history/pages/HistoryPage.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import useInterviewHistory from '../hooks/useInterviewHistory'
+import useDeleteInterview from '../hooks/useDeleteInterview'
+import InterviewHistoryCard from '../components/InterviewHistoryCard'
+import HistoryFilterBar from '../components/HistoryFilterBar'
+import DeleteConfirmDialog from '../components/DeleteConfirmDialog'
+import PaginationBar from '@/shared/components/ui/PaginationBar'
+import type { HistoryFilterState, InterviewSummary } from '../types'
+
+const PAGE_SIZE = 10
+
+const HistoryPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const currentPage = Number(searchParams.get('page') ?? '0')
+
+  const [filters, setFilters] = useState<HistoryFilterState>({
+    keyword: '',
+    interviewType: '',
+    sessionStatus: '',
+  })
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
+
+  const { data, isLoading, isError } = useInterviewHistory({
+    page: currentPage,
+    size: PAGE_SIZE,
+    interviewType: filters.interviewType || undefined,
+    sessionStatus: filters.sessionStatus || undefined,
+  })
+
+  const { mutate: doDelete, isPending: isDeleting } = useDeleteInterview(() => {
+    setDeleteTargetId(null)
+  })
+
+  const handleFilterChange = (next: HistoryFilterState) => {
+    setFilters(next)
+    setSearchParams({ page: '0' })
+  }
+
+  const handlePageChange = (page: number) => {
+    setSearchParams({ page: String(page) })
+  }
+
+  const filteredContent: InterviewSummary[] = (data?.content ?? []).filter((item) => {
+    if (!filters.keyword) return true
+    const kw = filters.keyword.toLowerCase()
+    return (
+      item.interviewType.toLowerCase().includes(kw) ||
+      item.difficulty.toLowerCase().includes(kw)
+    )
+  })
+
+  return (
+    <div className="p-8 max-w-3xl">
+      <h1 className="text-2xl font-bold text-[#131b2e] mb-1">면접 히스토리</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        지난 면접 연습 기록을 확인하고 AI 피드백을 통해 부족한 점을 보완하세요.
+      </p>
+
+      <div className="mb-6">
+        <HistoryFilterBar filters={filters} onFilterChange={handleFilterChange} />
+      </div>
+
+      {isLoading && (
+        <div className="space-y-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="bg-white rounded-xl border border-[#e8e8f0] p-5 h-28 animate-pulse" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <p className="text-sm text-red-500">면접 목록을 불러오는 중 오류가 발생했습니다.</p>
+      )}
+
+      {!isLoading && !isError && filteredContent.length === 0 && (
+        <p className="text-sm text-gray-400 py-10 text-center">면접 기록이 없습니다.</p>
+      )}
+
+      {!isLoading && !isError && filteredContent.length > 0 && (
+        <div className="space-y-4">
+          {filteredContent.map((interview) => (
+            <InterviewHistoryCard
+              key={interview.id}
+              interview={interview}
+              onDelete={(id) => setDeleteTargetId(id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {data && (
+        <PaginationBar
+          currentPage={currentPage}
+          totalPages={data.totalPages}
+          onPageChange={handlePageChange}
+        />
+      )}
+
+      <DeleteConfirmDialog
+        open={deleteTargetId !== null}
+        onConfirm={() => deleteTargetId !== null && doDelete(deleteTargetId)}
+        onCancel={() => setDeleteTargetId(null)}
+        isPending={isDeleting}
+      />
+    </div>
+  )
+}
+
+export default HistoryPage

--- a/front/src/features/history/types/index.ts
+++ b/front/src/features/history/types/index.ts
@@ -1,0 +1,32 @@
+import type { InterviewType, Difficulty, SessionStatus } from '@/shared/types/enums'
+
+export type { InterviewType, Difficulty, SessionStatus }
+
+export interface InterviewSummary {
+  id: number
+  interviewType: InterviewType
+  difficulty: Difficulty
+  questionCount: number
+  sessionStatus: SessionStatus
+  createdAt: string
+}
+
+export interface InterviewListResponse {
+  content: InterviewSummary[]
+  totalElements: number
+  totalPages: number
+  last: boolean
+}
+
+export interface InterviewListParams {
+  page?: number
+  size?: number
+  interviewType?: InterviewType
+  sessionStatus?: SessionStatus
+}
+
+export interface HistoryFilterState {
+  keyword: string
+  interviewType: InterviewType | ''
+  sessionStatus: SessionStatus | ''
+}

--- a/front/src/features/history/utils/formatDate.ts
+++ b/front/src/features/history/utils/formatDate.ts
@@ -1,0 +1,7 @@
+export const formatHistoryDate = (isoString: string): string => {
+  const date = new Date(isoString)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}.${month}.${day}`
+}

--- a/front/src/shared/api/constants.ts
+++ b/front/src/shared/api/constants.ts
@@ -22,5 +22,6 @@ export const API_PATHS = {
     currentQuestion: (interviewId: number) => `/api/interviews/${interviewId}/questions/current`,
     answers: (interviewId: number) => `/api/interviews/${interviewId}/answers`,
     report: (interviewId: number) => `/api/interviews/${interviewId}/report`,
+    delete: (interviewId: number) => `/api/interviews/${interviewId}`,
   },
 } as const

--- a/front/src/shared/components/ui/PaginationBar.tsx
+++ b/front/src/shared/components/ui/PaginationBar.tsx
@@ -1,0 +1,69 @@
+interface Props {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+const WINDOW = 2
+
+const PaginationBar = ({ currentPage, totalPages, onPageChange }: Props) => {
+  if (totalPages <= 1) return null
+
+  const pages: (number | '...')[] = []
+
+  if (totalPages <= 7) {
+    for (let i = 0; i < totalPages; i++) pages.push(i)
+  } else {
+    pages.push(0)
+    if (currentPage > WINDOW + 1) pages.push('...')
+    for (let i = Math.max(1, currentPage - WINDOW); i <= Math.min(totalPages - 2, currentPage + WINDOW); i++) {
+      pages.push(i)
+    }
+    if (currentPage < totalPages - WINDOW - 2) pages.push('...')
+    pages.push(totalPages - 1)
+  }
+
+  return (
+    <div className="flex items-center justify-center gap-1 mt-6">
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 0}
+        className="px-2 py-1 text-sm text-gray-500 disabled:opacity-30 hover:text-[#4648d4] transition-colors"
+        aria-label="이전 페이지"
+      >
+        &#8249;
+      </button>
+
+      {pages.map((p, idx) =>
+        p === '...' ? (
+          <span key={`ellipsis-${idx}`} className="px-2 py-1 text-sm text-gray-400">
+            ...
+          </span>
+        ) : (
+          <button
+            key={p}
+            onClick={() => onPageChange(p as number)}
+            className={`w-8 h-8 rounded-full text-sm font-medium transition-colors ${
+              p === currentPage
+                ? 'bg-[#4648d4] text-white'
+                : 'text-gray-600 hover:text-[#4648d4]'
+            }`}
+          >
+            {(p as number) + 1}
+          </button>
+        ),
+      )}
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages - 1}
+        className="px-2 py-1 text-sm text-gray-500 disabled:opacity-30 hover:text-[#4648d4] transition-colors"
+        aria-label="다음 페이지"
+      >
+        &#8250;
+      </button>
+    </div>
+  )
+}
+
+export default PaginationBar

--- a/front/src/shared/pages/HistoryPage.tsx
+++ b/front/src/shared/pages/HistoryPage.tsx
@@ -1,9 +1,1 @@
-const HistoryPage = () => {
-  return (
-    <div className="p-8">
-      <p className="text-gray-500">히스토리 (구현 예정)</p>
-    </div>
-  )
-}
-
-export default HistoryPage
+export { default } from '@/features/history/pages/HistoryPage'

--- a/front/src/shared/types/queryKeys.ts
+++ b/front/src/shared/types/queryKeys.ts
@@ -12,6 +12,6 @@ export const queryKeys = {
   },
   interviews: {
     all: ['interviews'] as const,
-    list: () => ['interviews', 'list'] as const,
+    list: (params?: Record<string, unknown>) => ['interviews', 'list', params] as const,
   },
 } as const


### PR DESCRIPTION
## Summary

- `features/history` 피처 폴더 전체 신규 구현
- 히스토리 카드, 검색/필터 바, 삭제 확인 다이얼로그, 페이지네이션 컴포넌트
- `shared/pages/HistoryPage.tsx` 플레이스홀더 → 실제 구현으로 교체

## Changes

**신규 생성**
- `features/history/types/index.ts` — InterviewSummary, 필터 타입
- `features/history/api/historyApi.ts` — getInterviewList, deleteInterview
- `features/history/hooks/useInterviewHistory.ts` — useQuery (placeholderData v5)
- `features/history/hooks/useDeleteInterview.ts` — useMutation (invalidate on success)
- `features/history/utils/formatDate.ts` — YYYY.MM.DD 날짜 포맷
- `features/history/components/InterviewHistoryCard.tsx` — 유형/난이도 뱃지, 상태 표시, 삭제 아이콘
- `features/history/components/HistoryFilterBar.tsx` — 키워드 검색 + 유형/상태 필터
- `features/history/components/DeleteConfirmDialog.tsx` — 삭제 확인 모달
- `features/history/pages/HistoryPage.tsx` — 메인 히스토리 페이지
- `shared/components/ui/PaginationBar.tsx` — 공유 페이지네이션

**수정**
- `shared/pages/HistoryPage.tsx` — features/history re-export
- `shared/api/constants.ts` — delete 경로 추가
- `shared/types/queryKeys.ts` — list(params) 필터 지원

## Test plan

- [x] `npm run typecheck` 통과
- [x] `npm run build` 성공
- [ ] `/history` 접근 후 목록 렌더링 확인
- [ ] 인터뷰 타입 필터 선택 → 서버 파라미터로 전달 확인
- [ ] 키워드 검색 → 클라이언트 필터링 동작 확인
- [ ] 삭제 아이콘 클릭 → Dialog → 확인 → 목록 갱신 확인
- [ ] "결과 보기 >" 클릭 → /interviews/:id/result 이동 확인
- [ ] "이어하기" 버튼 disabled 상태 확인
- [ ] 페이지네이션 클릭 → URL page 파라미터 변경 확인

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **면접 이력 페이지**
  * 면접 이력 조회 페이지 추가
  * 면접 유형, 상태, 키워드로 필터링 가능
  * 페이지네이션을 통한 이력 관리
  * 각 면접의 난이도, 날짜, 문제 수 표시
  
* **면접 관리 기능**
  * 완료한 면접의 결과 조회 기능
  * 진행 중인 면접 계속하기 기능
  * 면접 삭제 확인 대화상자 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->