### PR TITLE
[#40] 프론트 운영 API 주소 설정

### DIFF
--- a/front/.env.production
+++ b/front/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://intervai.kro.kr


### PR DESCRIPTION
## 📌 개요
- 운영 빌드에서 프런트엔드가 백엔드 서버 도메인 `https://intervai.kro.kr`을 바라보도록 설정합니다.

## ✨ 변경 사항
- `front/.env.production` 추가
- `VITE_API_BASE_URL=https://intervai.kro.kr` 설정
- 운영 Vite 빌드 시 API base URL이 운영 서버 도메인으로 주입되도록 반영

## 🔥 변경 이유(선택)
- 운영 배포 환경에서 프런트엔드 API 호출 대상이 localhost로 남는 문제를 방지하기 위함입니다.

## 🧪 테스트
- [x] 로컬 테스트 완료
- `npm run build`: 통과
- 수동 테스트: approved

## 🤔 고민한 부분 (선택)
- 기존 `BASE_URL` fallback은 로컬 개발 기본값으로 유지하고, 운영 빌드 설정만 별도 env 파일로 분리했습니다.

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [x] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [x] 문서 업데이트 (필요 시)

## 🔗 관련 이슈
- Related to #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 프로덕션 환경 설정을 업데이트하여 애플리케이션이 올바르게 배포되도록 구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->