### PR TITLE
[#40] Healthcheck API 및 운영 배포 설정 추가

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,9 +1,6 @@
 services:
   spring-app:
     image: ${APP_IMAGE:-wlsh44/intervai-spring:latest}
-    build:
-      context: .
-      dockerfile: Dockerfile
     container_name: intervai-spring
     restart: unless-stopped
     ports:

--- a/docs/notes/issue-40.md
+++ b/docs/notes/issue-40.md
@@ -1,0 +1,19 @@
+# Issue 40 작업 로그
+
+## 주요 결정사항
+
+- `GET /api/health`는 인증 없이 호출 가능한 운영 확인용 API로 추가했다.
+- Healthcheck는 비즈니스 로직이 없으므로 별도 Service 계층 없이 얇은 Controller와 응답 record만 두었다.
+- 프런트 운영 API 주소는 `front/.env.production`에 `VITE_API_BASE_URL=https://intervai.kro.kr`로 분리했다.
+- 운영 인스턴스에서는 GitHub Actions가 publish한 이미지를 pull해서 실행하므로 `compose.yml`의 로컬 `build` 설정을 제거했다.
+
+## 포기한 접근법
+
+- Spring Boot Actuator 도입은 현재 요구 범위보다 크고 의존성/노출 경로 관리가 추가로 필요해 사용하지 않았다.
+- 프런트 API 기본값 자체를 운영 도메인으로 바꾸는 방식은 로컬 개발 기본 동작을 깨뜨릴 수 있어 사용하지 않았다.
+
+## 다음 작업 참고
+
+- `GET /api/health` 응답은 현재 `{"status":"UP"}`만 반환한다.
+- 운영 서버 `.env`에는 프런트 CORS 허용 도메인과 백엔드 런타임 환경변수가 별도로 유지되어야 한다.
+- #40은 백엔드 PR과 프런트엔드 PR을 분리했으며, API 문서 스펙 변경은 선행 커밋으로 `main`에 반영했다.

--- a/src/main/java/wlsh/project/intervai/common/config/SecurityConfig.java
+++ b/src/main/java/wlsh/project/intervai/common/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/api/health").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/users/sign-up").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/users/login").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()

--- a/src/main/java/wlsh/project/intervai/common/presentation/HealthController.java
+++ b/src/main/java/wlsh/project/intervai/common/presentation/HealthController.java
@@ -1,0 +1,15 @@
+package wlsh.project.intervai.common.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wlsh.project.intervai.common.presentation.dto.HealthResponse;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/api/health")
+    public ResponseEntity<HealthResponse> health() {
+        return ResponseEntity.ok(new HealthResponse("UP"));
+    }
+}

--- a/src/main/java/wlsh/project/intervai/common/presentation/dto/HealthResponse.java
+++ b/src/main/java/wlsh/project/intervai/common/presentation/dto/HealthResponse.java
@@ -1,0 +1,6 @@
+package wlsh.project.intervai.common.presentation.dto;
+
+public record HealthResponse(
+        String status
+) {
+}

--- a/src/test/java/wlsh/project/intervai/common/presentation/HealthControllerTest.java
+++ b/src/test/java/wlsh/project/intervai/common/presentation/HealthControllerTest.java
@@ -1,0 +1,24 @@
+package wlsh.project.intervai.common.presentation;
+
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import wlsh.project.intervai.common.AcceptanceTest;
+
+import static org.hamcrest.Matchers.equalTo;
+
+@WebMvcTest(HealthController.class)
+class HealthControllerTest extends AcceptanceTest {
+
+    @Test
+    @DisplayName("헬스체크 API는 인증 없이 200과 서버 상태를 반환한다")
+    void health() {
+        RestAssuredMockMvc.given()
+        .when()
+                .get("/api/health")
+        .then()
+                .statusCode(200)
+                .body("status", equalTo("UP"));
+    }
+}


### PR DESCRIPTION
## 📌 개요
- 운영 배포 상태 확인을 위한 인증 없는 healthcheck API를 추가하고, 서버 배포용 compose 설정을 이미지 pull 기반으로 정리합니다.

## ✨ 변경 사항
- `GET /api/health` API 추가
- `/api/health` 경로를 Spring Security 인증 예외로 허용
- healthcheck controller 테스트 추가
- 운영 compose 설정에서 로컬 build 블록 제거

## 🔥 변경 이유(선택)
- 배포 스크립트, 모니터링, 외부 확인에서 서버 상태를 인증 없이 확인할 수 있어야 합니다.
- 운영 인스턴스에서는 GitHub Actions가 publish한 이미지를 pull해서 실행하므로 compose의 로컬 build 설정이 불필요합니다.

## 🧪 테스트
- [x] 로컬 테스트 완료
- `./gradlew test`: 통과
- 수동 테스트: approved

## 🤔 고민한 부분 (선택)
- healthcheck는 비즈니스 로직이 없으므로 별도 서비스 계층 없이 얇은 controller와 response record만 추가했습니다.

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [x] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [x] 문서 업데이트 (필요 시)

## 🔗 관련 이슈
- Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증 없이 접근 가능한 헬스 체크 엔드포인트 추가

* **문서**
  * Issue 40 작업 로그 및 결정사항 문서 추가

* **Chores**
  * Docker Compose 설정 업데이트 - 사전 빌드된 이미지 사용으로 변경

* **Tests**
  * 헬스 체크 엔드포인트 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->