### PR TITLE
포트폴리오 링크 GitHub public 저장소 검증 추가

### DIFF
--- a/docs/notes/issue-43.md
+++ b/docs/notes/issue-43.md
@@ -1,0 +1,29 @@
+# Issue 43 작업 로그
+
+## 주요 결정사항
+
+- 포트폴리오 면접 질문 생성 시 GitHub 저장소 링크를 분석해 LLM 프롬프트에 주입하도록 구현했다.
+- API 요청/응답 형식은 유지했다. 기존 `portfolioLinks` 입력값을 활용해 질문 생성 단계에서 GitHub API를 호출한다.
+- GitHub 분석 결과는 저장하지 않고 질문 생성 시점에만 사용한다. 저장소 설명, 기본 브랜치, 주요 언어, 언어 구성, README 일부를 프롬프트 컨텍스트로 전달한다.
+- GitHub 분석 실패는 면접 질문 생성 실패로 전파하지 않고, 실패 사유를 프롬프트에 포함한다.
+- 실제 LLM API 통신 검증은 `RUN_LLM_API_TESTS=true` 환경변수로 켜는 수동 테스트로 분리했다.
+- 프런트에서는 포트폴리오 링크 추가 시 GitHub URL 형식과 public repository 접근 가능 여부를 확인한 뒤 등록하도록 했다.
+
+## 포기한 접근법
+
+- GitHub 분석 결과를 DB에 저장하는 방식은 현재 요구보다 범위가 커서 제외했다.
+- private repository 인증 연동은 사용자 토큰 관리가 필요하므로 이번 범위에서 제외했다.
+- 커밋 패턴 분석은 GitHub API 호출량과 프롬프트 길이가 커질 수 있어 README/언어 구성 기반 분석을 우선 적용했다.
+- 프런트에서 GitHub 인증 토큰을 받아 private repository까지 확인하는 방식은 사용자 토큰 관리 범위가 추가되어 제외했다.
+
+## 다음 작업 참고
+
+- 수동 LLM 테스트는 아래처럼 실행한다.
+
+```bash
+API_KEY=your_gemini_api_key RUN_LLM_API_TESTS=true ./gradlew test --tests "wlsh.project.intervai.question.infra.QuestionGeneratorLlmApiManualTest"
+```
+
+- `.env`를 사용할 경우 `set -a; source .env; set +a` 후 동일한 Gradle 명령을 실행하면 된다.
+- GitHub API rate limit, private repository, 대용량 README 요약 정책은 이후 별도 이슈에서 고도화할 수 있다.
+- 프런트 PR은 백엔드 PR과 같은 작업 로그 파일을 추가하므로 병합 순서에 따라 rebase가 필요할 수 있다.

--- a/front/src/features/interview/components/PortfolioLinkInput.tsx
+++ b/front/src/features/interview/components/PortfolioLinkInput.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
 import { X, Plus, Loader2 } from 'lucide-react'
 import { checkPublicGithubRepository, parseGithubRepositoryUrl } from '../utils/githubRepository'
 
@@ -13,7 +14,10 @@ interface PortfolioLinkInputProps {
 const PortfolioLinkInput = ({ value, onChange, error }: PortfolioLinkInputProps) => {
   const [inputValue, setInputValue] = useState('')
   const [urlError, setUrlError] = useState('')
-  const [isChecking, setIsChecking] = useState(false)
+  const { mutateAsync: validateRepository, isPending: isChecking } = useMutation({
+    mutationFn: checkPublicGithubRepository,
+    retry: false,
+  })
 
   const addLink = async () => {
     const trimmed = inputValue.trim()
@@ -31,9 +35,7 @@ const PortfolioLinkInput = ({ value, onChange, error }: PortfolioLinkInputProps)
       return
     }
 
-    setIsChecking(true)
-    const isPublicRepository = await checkPublicGithubRepository(repository).catch(() => false)
-    setIsChecking(false)
+    const isPublicRepository = await validateRepository(repository)
 
     if (!isPublicRepository) {
       setUrlError('접근 가능한 public GitHub 저장소만 등록할 수 있습니다.')

--- a/front/src/features/interview/components/PortfolioLinkInput.tsx
+++ b/front/src/features/interview/components/PortfolioLinkInput.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { X, Plus } from 'lucide-react'
+import { X, Plus, Loader2 } from 'lucide-react'
+import { checkPublicGithubRepository, parseGithubRepositoryUrl } from '../utils/githubRepository'
 
 const MAX_LINKS = 5
 
@@ -12,22 +13,36 @@ interface PortfolioLinkInputProps {
 const PortfolioLinkInput = ({ value, onChange, error }: PortfolioLinkInputProps) => {
   const [inputValue, setInputValue] = useState('')
   const [urlError, setUrlError] = useState('')
+  const [isChecking, setIsChecking] = useState(false)
 
-  const addLink = () => {
+  const addLink = async () => {
     const trimmed = inputValue.trim()
     if (!trimmed) return
 
-    try {
-      new URL(trimmed)
-    } catch {
-      setUrlError('올바른 URL 형식을 입력해주세요. (예: https://github.com/your-project)')
+    const repository = parseGithubRepositoryUrl(trimmed)
+    if (!repository) {
+      setUrlError('GitHub 공개 저장소 URL을 입력해주세요. (예: https://github.com/user/repo)')
       return
     }
 
-    setUrlError('')
+    if (value.includes(repository.normalizedUrl)) {
+      setUrlError('')
+      setInputValue('')
+      return
+    }
+
+    setIsChecking(true)
+    const isPublicRepository = await checkPublicGithubRepository(repository).catch(() => false)
+    setIsChecking(false)
+
+    if (!isPublicRepository) {
+      setUrlError('접근 가능한 public GitHub 저장소만 등록할 수 있습니다.')
+      return
+    }
+
     setInputValue('')
-    if (value.length >= MAX_LINKS || value.includes(trimmed)) return
-    onChange([...value, trimmed])
+    if (value.length >= MAX_LINKS) return
+    onChange([...value, repository.normalizedUrl])
   }
 
   const removeLink = (link: string) => {
@@ -37,7 +52,7 @@ const PortfolioLinkInput = ({ value, onChange, error }: PortfolioLinkInputProps)
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault()
-      addLink()
+      void addLink()
     }
   }
 
@@ -51,18 +66,18 @@ const PortfolioLinkInput = ({ value, onChange, error }: PortfolioLinkInputProps)
           value={inputValue}
           onChange={(e) => { setInputValue(e.target.value); setUrlError('') }}
           onKeyDown={handleKeyDown}
-          disabled={isMaxReached}
+          disabled={isMaxReached || isChecking}
           placeholder="https://github.com/your-project"
           className="flex-1 px-3 py-2 border border-[#767586] rounded-lg text-sm text-[#131b2e] placeholder:text-[#767586] outline-none focus:border-[#4648d4] disabled:bg-gray-50 disabled:cursor-not-allowed"
         />
         <button
           type="button"
-          onClick={addLink}
-          disabled={isMaxReached || !inputValue.trim()}
+          onClick={() => { void addLink() }}
+          disabled={isMaxReached || !inputValue.trim() || isChecking}
           className="flex items-center gap-1 px-4 py-2 bg-[#4648d4] text-white rounded-lg text-sm font-medium hover:bg-[#3537b0] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          <Plus size={16} />
-          추가
+          {isChecking ? <Loader2 size={16} className="animate-spin" /> : <Plus size={16} />}
+          {isChecking ? '확인 중' : '추가'}
         </button>
       </div>
 

--- a/front/src/features/interview/utils/githubRepository.ts
+++ b/front/src/features/interview/utils/githubRepository.ts
@@ -1,0 +1,51 @@
+const GITHUB_HOST = 'github.com'
+
+export interface GithubRepositoryPath {
+  owner: string
+  repo: string
+  normalizedUrl: string
+}
+
+export const parseGithubRepositoryUrl = (rawUrl: string): GithubRepositoryPath | null => {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== 'https:' || url.hostname.toLowerCase() !== GITHUB_HOST) {
+    return null
+  }
+
+  const [owner, repoSegment] = url.pathname.split('/').filter(Boolean)
+  if (!owner || !repoSegment) {
+    return null
+  }
+
+  const repo = repoSegment.replace(/\.git$/, '')
+  if (!repo) {
+    return null
+  }
+
+  return {
+    owner,
+    repo,
+    normalizedUrl: `https://github.com/${owner}/${repo}`,
+  }
+}
+
+export const checkPublicGithubRepository = async (repository: GithubRepositoryPath): Promise<boolean> => {
+  const response = await fetch(`https://api.github.com/repos/${repository.owner}/${repository.repo}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+    },
+  })
+
+  if (!response.ok) {
+    return false
+  }
+
+  const body = (await response.json()) as { private?: boolean }
+  return body.private === false
+}

--- a/front/src/features/interview/utils/githubRepository.ts
+++ b/front/src/features/interview/utils/githubRepository.ts
@@ -1,9 +1,16 @@
+import axios from 'axios'
+
 const GITHUB_HOST = 'github.com'
+const GITHUB_API_TIMEOUT_MS = 5000
 
 export interface GithubRepositoryPath {
   owner: string
   repo: string
   normalizedUrl: string
+}
+
+interface GithubRepositoryResponse {
+  private?: boolean
 }
 
 export const parseGithubRepositoryUrl = (rawUrl: string): GithubRepositoryPath | null => {
@@ -14,7 +21,8 @@ export const parseGithubRepositoryUrl = (rawUrl: string): GithubRepositoryPath |
     return null
   }
 
-  if (url.protocol !== 'https:' || url.hostname.toLowerCase() !== GITHUB_HOST) {
+  const hostname = url.hostname.toLowerCase()
+  if (url.protocol !== 'https:' || (hostname !== GITHUB_HOST && hostname !== `www.${GITHUB_HOST}`)) {
     return null
   }
 
@@ -36,16 +44,19 @@ export const parseGithubRepositoryUrl = (rawUrl: string): GithubRepositoryPath |
 }
 
 export const checkPublicGithubRepository = async (repository: GithubRepositoryPath): Promise<boolean> => {
-  const response = await fetch(`https://api.github.com/repos/${repository.owner}/${repository.repo}`, {
-    headers: {
-      Accept: 'application/vnd.github+json',
-    },
-  })
+  try {
+    const response = await axios.get<GithubRepositoryResponse>(
+      `https://api.github.com/repos/${repository.owner}/${repository.repo}`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+        },
+        timeout: GITHUB_API_TIMEOUT_MS,
+      },
+    )
 
-  if (!response.ok) {
+    return response.data.private === false
+  } catch {
     return false
   }
-
-  const body = (await response.json()) as { private?: boolean }
-  return body.private === false
 }


### PR DESCRIPTION
## 📌 개요
- 포트폴리오 면접 설정에서 입력한 링크가 GitHub public repository인지 확인한 뒤 등록하도록 개선했습니다.

## ✨ 변경 사항
- GitHub 저장소 URL 파싱/정규화 유틸 추가
- 포트폴리오 링크 추가 시 GitHub API로 public repository 접근 가능 여부 확인
- 확인 중 로딩 상태와 실패 메시지 표시

## 🔥 변경 이유(선택)
- 백엔드가 GitHub 저장소 분석을 수행하므로, 프런트에서 잘못된 URL과 private repository 입력을 사전에 차단하기 위함입니다.

## 🧪 테스트
- [x] 로컬 테스트 완료
- front/ npm run build
- front/ npm run lint

## 🤔 고민한 부분 (선택)
- GitHub API 확인 실패는 private 또는 접근 불가 저장소와 동일하게 등록 불가로 처리했습니다.

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [ ] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [x] 문서 업데이트 (필요 시)

## 🔗 관련 이슈
- Closes #43


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 포트폴리오 링크 입력에 GitHub 저장소 URL 비동기 검증 추가
  * 저장소 공개 여부 자동 확인 및 비공개·존재하지 않는 저장소에 대한 안전한 처리
  * 검증 중 입력 비활성화, 버튼 스피너 및 진행 라벨 표시 등 UX 개선
  * Enter/클릭 시 비동기 검증 흐름 적용 및 한국어 오류 메시지 제공

* **문서**
  * 작업 로그, 결정사항, 테스트 가이드 등을 담은 이슈 문서 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->