### PR TITLE
[#23] CS 주제 선택 UX 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
 # IntervAI
+
+IntervAI는 개발자 면접 연습을 위한 AI 기반 서비스의 백엔드 애플리케이션입니다.  
+사용자의 기본 정보, 기술 스택, 포트폴리오 링크를 바탕으로 면접 세션을 만들고, AI 질문 생성, 답변 피드백, 꼬리 질문, 면접 리포트 생성을 담당합니다.
+
+![이미지 관련 아키텍처]()
+
+## 주요 기능
+
+- 회원가입, 로그인, JWT 기반 인증
+- 직군, 경력, 기술 스택, 포트폴리오 링크 관리
+- CS/프로젝트 기반 면접 세션 생성
+- AI 질문 생성 및 답변 제출
+- 답변별 피드백과 점수 제공
+- 세션 히스토리 조회 및 면접 결과 리포트
+
+## 기술 스택
+
+- Java 21
+- Spring Boot 3.5
+- Spring Security, Spring Data JPA, Validation
+- Spring AI
+- MySQL, Redis, H2(local/test)
+- Gradle
+
+## 프로젝트 구조
+
+```text
+.
+├── src/main/java/wlsh/project/intervai
+│   ├── common       # 공통 설정, 인증, 예외 처리
+│   ├── user         # 사용자 계정
+│   ├── profile      # 프로필, 기술 스택, 포트폴리오 링크
+│   ├── interview    # 면접 생성 및 진행
+│   ├── question     # 질문 생성
+│   ├── answer       # 답변 제출 및 결과 생성
+│   ├── feedback     # 피드백 저장/조회
+│   ├── session      # 면접 세션 히스토리
+│   └── report       # 면접 리포트
+└── docs             # 기능 명세 및 API 문서
+```
+
+> 다이어그램 추가 추천: 백엔드 도메인 간 관계가 확정되면 이 위치에 간단한 아키텍처 다이어그램을 추가하면 좋습니다.
+
+## 로컬 실행
+
+```bash
+./gradlew bootRun
+```
+
+기본 실행 프로파일은 `local`입니다. 로컬 개발에서는 필요에 따라 `local-seed`, `local-ollama`, `local-gemini` 등 리소스 프로파일을 선택해 실행합니다.
+
+```bash
+./gradlew bootRun --args='--spring.profiles.active=local,local-seed'
+```
+
+## 테스트
+
+```bash
+./gradlew test
+```
+
+## 문서
+
+- [문서 인덱스](docs/README.md)
+- [API 문서](docs/api.md)
+- [아키텍처 및 코딩 규칙](docs/architecture.md)
+
+> 시퀀스 다이어그램 추가 추천: 면접 세션 생성 → 질문 생성 → 답변 제출 → 피드백/꼬리 질문 생성 흐름은 `docs/api.md` 또는 README 하단에 Mermaid 시퀀스 다이어그램으로 정리하기 좋습니다.

--- a/front/README.md
+++ b/front/README.md
@@ -1,73 +1,64 @@
-# React + TypeScript + Vite
+# IntervAI Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+IntervAI의 프론트엔드 애플리케이션입니다.  
+사용자 인증, 프로필 관리, 면접 설정, AI 면접 진행, 히스토리와 결과 리포트 화면을 제공합니다.
 
-Currently, two official plugins are available:
+> 이미지 추가 추천: 이 위치에 대시보드, 면접 진행 화면, 결과 리포트 화면 스크린샷을 배치하면 좋습니다.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## 주요 기능
 
-## React Compiler
+- 회원가입 및 로그인
+- 대시보드와 최근 면접 기록 조회
+- 프로필, 기술 스택, 포트폴리오 링크 관리
+- 면접 유형, 난이도, 질문 수, 면접관 톤 설정
+- 채팅형 면접 진행 및 답변 제출
+- 답변 피드백, 세션 종료, 결과 리포트 확인
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+## 기술 스택
 
-## Expanding the ESLint configuration
+- React
+- TypeScript
+- Vite
+- React Router
+- Zustand
+- TanStack Query
+- Axios
+- React Hook Form
+- Zod
+- Tailwind CSS
+- lucide-react
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+## 프로젝트 구조
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```text
+front
+├── src
+│   ├── app              # 앱 엔트리와 라우터
+│   ├── features
+│   │   ├── auth         # 인증
+│   │   ├── dashboard    # 대시보드
+│   │   ├── history      # 면접 히스토리
+│   │   ├── interview    # 면접 설정 및 진행
+│   │   └── profile      # 프로필 관리
+│   └── shared           # 공통 API, 레이아웃, UI, 타입
+└── package.json
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+> 다이어그램 추가 추천: 로그인 → 프로필 입력 → 면접 설정 → 채팅 진행 → 결과 리포트 흐름은 간단한 화면 플로우 다이어그램으로 정리하기 좋습니다.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## 로컬 실행
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev
+```
+
+기본 개발 서버는 Vite 설정을 따릅니다.
+
+## 테스트 및 빌드
+
+```bash
+npm run typecheck
+npm run lint
+npm run build
 ```

--- a/front/src/features/interview/components/CsSubjectsSelector.tsx
+++ b/front/src/features/interview/components/CsSubjectsSelector.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import type { CsCategory } from '../../../shared/types/enums'
 import type { CsSubjectRequest } from '../api/interviewApi'
 
@@ -19,6 +21,12 @@ const CATEGORY_LABELS: Record<CsCategory, string> = {
 
 const CATEGORIES: CsCategory[] = ['DATA_STRUCTURE', 'ALGORITHM', 'NETWORK', 'LANGUAGE', 'DATABASE']
 
+const splitCustomTopics = (text: string): string[] =>
+  text
+    .split(',')
+    .map((topic) => topic.trim())
+    .filter(Boolean)
+
 interface CsSubjectsSelectorProps {
   value: CsSubjectRequest[]
   onChange: (v: CsSubjectRequest[]) => void
@@ -26,17 +34,52 @@ interface CsSubjectsSelectorProps {
 }
 
 const CsSubjectsSelector = ({ value, onChange, error }: CsSubjectsSelectorProps) => {
+  const [customInputs, setCustomInputs] = useState<Partial<Record<CsCategory, string>>>({})
+
+  const updateCategory = (category: CsCategory, topics: string[]) => {
+    const existing = value.find((s) => s.category === category)
+    if (existing) {
+      onChange(value.map((s) => (s.category === category ? { ...s, topics } : s)))
+    } else {
+      onChange([...value, { category, topics }])
+    }
+  }
+
+  const removeCategory = (category: CsCategory) => {
+    onChange(value.filter((s) => s.category !== category))
+  }
+
+  const clearCustomInput = (category: CsCategory) => {
+    setCustomInputs((prev) => {
+      const next = { ...prev }
+      delete next[category]
+      return next
+    })
+  }
+
   const getTopicsForCategory = (category: CsCategory): string[] => {
     const found = value.find((s) => s.category === category)
     return found ? found.topics : []
   }
 
   const isAllSelected = (category: CsCategory): boolean => {
+    return value.some((s) => s.category === category && s.topics.length === 0)
+  }
+
+  const getCustomTopicsText = (category: CsCategory): string => {
+    if (customInputs[category] !== undefined) {
+      return customInputs[category] ?? ''
+    }
+
     const selected = getTopicsForCategory(category)
-    return selected.length === CS_TOPICS[category].length
+    if (selected.length === 0) return ''
+    if (selected.every((topic) => CS_TOPICS[category].includes(topic))) return ''
+    return selected.join(', ')
   }
 
   const toggleTopic = (category: CsCategory, topic: string) => {
+    if (isAllSelected(category) || getCustomTopicsText(category)) return
+
     const currentTopics = getTopicsForCategory(category)
     const isTopicSelected = currentTopics.includes(topic)
 
@@ -47,28 +90,33 @@ const CsSubjectsSelector = ({ value, onChange, error }: CsSubjectsSelectorProps)
       newTopics = [...currentTopics, topic]
     }
 
-    const existing = value.find((s) => s.category === category)
+    clearCustomInput(category)
     if (newTopics.length === 0) {
-      onChange(value.filter((s) => s.category !== category))
-    } else if (existing) {
-      onChange(value.map((s) => (s.category === category ? { ...s, topics: newTopics } : s)))
+      removeCategory(category)
     } else {
-      onChange([...value, { category, topics: newTopics }])
+      updateCategory(category, newTopics)
     }
   }
 
   const toggleAll = (category: CsCategory) => {
+    clearCustomInput(category)
     if (isAllSelected(category)) {
-      onChange(value.filter((s) => s.category !== category))
+      removeCategory(category)
     } else {
-      const allTopics = CS_TOPICS[category]
-      const existing = value.find((s) => s.category === category)
-      if (existing) {
-        onChange(value.map((s) => (s.category === category ? { ...s, topics: allTopics } : s)))
-      } else {
-        onChange([...value, { category, topics: allTopics }])
-      }
+      updateCategory(category, [])
     }
+  }
+
+  const handleCustomTopicsChange = (category: CsCategory, text: string) => {
+    setCustomInputs((prev) => ({ ...prev, [category]: text }))
+
+    const customTopics = splitCustomTopics(text)
+    if (customTopics.length === 0) {
+      removeCategory(category)
+      return
+    }
+
+    updateCategory(category, customTopics)
   }
 
   return (
@@ -76,6 +124,8 @@ const CsSubjectsSelector = ({ value, onChange, error }: CsSubjectsSelectorProps)
       {CATEGORIES.map((category) => {
         const selectedTopics = getTopicsForCategory(category)
         const allSelected = isAllSelected(category)
+        const customTopicsText = getCustomTopicsText(category)
+        const hasCustomTopics = customTopicsText.length > 0
 
         return (
           <div key={category} className="bg-white rounded-xl p-4 border border-[#e2e7ff]">
@@ -84,9 +134,9 @@ const CsSubjectsSelector = ({ value, onChange, error }: CsSubjectsSelectorProps)
               <button
                 type="button"
                 onClick={() => toggleAll(category)}
-                className="text-xs text-[#4648d4] hover:underline"
+                className={`text-xs ${allSelected ? 'text-[#ba1a1a]' : 'text-[#4648d4]'} hover:underline`}
               >
-                {allSelected ? '전체 해제' : '전체 선택'}
+                {allSelected ? '전체 해제' : '전체'}
               </button>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -96,8 +146,9 @@ const CsSubjectsSelector = ({ value, onChange, error }: CsSubjectsSelectorProps)
                   <button
                     key={topic}
                     type="button"
+                    disabled={allSelected || hasCustomTopics}
                     onClick={() => toggleTopic(category, topic)}
-                    className={`px-3 py-1 rounded-full text-xs transition-colors ${
+                    className={`px-3 py-1 rounded-full text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
                       isSelected
                         ? 'bg-[#4648d4] text-white'
                         : 'border border-[#767586] text-[#767586] hover:border-[#4648d4]'
@@ -108,6 +159,14 @@ const CsSubjectsSelector = ({ value, onChange, error }: CsSubjectsSelectorProps)
                 )
               })}
             </div>
+            <input
+              type="text"
+              value={customTopicsText}
+              onChange={(e) => handleCustomTopicsChange(category, e.target.value)}
+              disabled={allSelected || (selectedTopics.length > 0 && !hasCustomTopics)}
+              placeholder={allSelected ? '전체 범위에서 랜덤 질문 생성' : '직접 입력, 쉼표로 여러 개 구분'}
+              className="mt-3 w-full rounded-lg border border-[#d8ddf0] px-3 py-2 text-xs text-[#131b2e] placeholder:text-[#9ca0b5] focus:outline-none focus:ring-2 focus:ring-[#4648d4]/20 disabled:bg-[#f5f6fb] disabled:text-[#767586]"
+            />
           </div>
         )
       })}

--- a/front/src/features/interview/components/CsSubjectsSelector.tsx
+++ b/front/src/features/interview/components/CsSubjectsSelector.tsx
@@ -20,6 +20,7 @@ const CATEGORY_LABELS: Record<CsCategory, string> = {
 }
 
 const CATEGORIES: CsCategory[] = ['DATA_STRUCTURE', 'ALGORITHM', 'NETWORK', 'LANGUAGE', 'DATABASE']
+const ALL_TOPICS = 'ALL'
 
 const splitCustomTopics = (text: string): string[] =>
   text
@@ -63,7 +64,7 @@ const CsSubjectsSelector = ({ value, onChange, error }: CsSubjectsSelectorProps)
   }
 
   const isAllSelected = (category: CsCategory): boolean => {
-    return value.some((s) => s.category === category && s.topics.length === 0)
+    return value.some((s) => s.category === category && s.topics.length === 1 && s.topics[0] === ALL_TOPICS)
   }
 
   const getCustomTopicsText = (category: CsCategory): string => {
@@ -73,6 +74,7 @@ const CsSubjectsSelector = ({ value, onChange, error }: CsSubjectsSelectorProps)
 
     const selected = getTopicsForCategory(category)
     if (selected.length === 0) return ''
+    if (selected.length === 1 && selected[0] === ALL_TOPICS) return ''
     if (selected.every((topic) => CS_TOPICS[category].includes(topic))) return ''
     return selected.join(', ')
   }
@@ -103,7 +105,7 @@ const CsSubjectsSelector = ({ value, onChange, error }: CsSubjectsSelectorProps)
     if (isAllSelected(category)) {
       removeCategory(category)
     } else {
-      updateCategory(category, [])
+      updateCategory(category, [ALL_TOPICS])
     }
   }
 

--- a/front/src/features/interview/components/InterviewSetupForm.tsx
+++ b/front/src/features/interview/components/InterviewSetupForm.tsx
@@ -106,7 +106,7 @@ const InterviewSetupForm = () => {
   const onSubmit = (data: InterviewSetupFormValues) => {
     const csSubjects: CsSubjectRequest[] | undefined =
       showCsSection
-        ? data.csSubjects.filter((s) => s.topics.length > 0)
+        ? data.csSubjects
         : undefined
 
     mutate({

--- a/front/src/features/interview/components/InterviewSetupSummary.tsx
+++ b/front/src/features/interview/components/InterviewSetupSummary.tsx
@@ -48,7 +48,7 @@ const TONE_LABELS: Record<InterviewerTone, string> = {
 const InterviewSetupSummary = ({ formValues }: InterviewSetupSummaryProps) => {
   const { jobCategory, interviewType, difficulty, questionCount, interviewerTone, csSubjects, portfolioLinks, techStacks } = formValues
 
-  const totalCsTopics = csSubjects.reduce((sum, s) => sum + s.topics.length, 0)
+  const totalCsSelections = csSubjects.reduce((sum, s) => sum + (s.topics.length === 0 ? 1 : s.topics.length), 0)
   const showCsSection = interviewType === 'CS' || interviewType === 'ALL'
   const showPortfolioSection = interviewType === 'PORTFOLIO' || interviewType === 'ALL'
 
@@ -58,7 +58,7 @@ const InterviewSetupSummary = ({ formValues }: InterviewSetupSummaryProps) => {
     { label: '난이도', value: difficulty ? DIFFICULTY_LABELS[difficulty] : '-' },
     { label: '질문 수', value: `${questionCount}문제` },
     { label: '면접관 스타일', value: interviewerTone ? TONE_LABELS[interviewerTone] : '-' },
-    ...(showCsSection ? [{ label: 'CS 과목 수', value: `${totalCsTopics}개` }] : []),
+    ...(showCsSection ? [{ label: 'CS 선택 수', value: `${totalCsSelections}개` }] : []),
     ...(showPortfolioSection
       ? [
           { label: '기술 스택 수', value: `${techStacks.length}개` },

--- a/front/src/features/interview/components/InterviewSetupSummary.tsx
+++ b/front/src/features/interview/components/InterviewSetupSummary.tsx
@@ -48,7 +48,7 @@ const TONE_LABELS: Record<InterviewerTone, string> = {
 const InterviewSetupSummary = ({ formValues }: InterviewSetupSummaryProps) => {
   const { jobCategory, interviewType, difficulty, questionCount, interviewerTone, csSubjects, portfolioLinks, techStacks } = formValues
 
-  const totalCsSelections = csSubjects.reduce((sum, s) => sum + (s.topics.length === 0 ? 1 : s.topics.length), 0)
+  const totalCsSelections = csSubjects.reduce((sum, s) => sum + (s.topics.length === 1 && s.topics[0] === 'ALL' ? 1 : s.topics.length), 0)
   const showCsSection = interviewType === 'CS' || interviewType === 'ALL'
   const showPortfolioSection = interviewType === 'PORTFOLIO' || interviewType === 'ALL'
 


### PR DESCRIPTION
## 📌 개요
- #23 CS 면접 주제 선택 개선 중 프론트엔드 선택 UI와 제출 payload를 구현합니다.

## ✨ 변경 사항
- 카테고리별 "전체" 선택 버튼 추가
- 카테고리별 직접 입력 필드 추가 및 쉼표 구분 입력 지원
- `전체/개별주제/직접입력` 선택 상태를 상호 배타적으로 처리

## 🔥 변경 이유(선택)
- 사용자가 예시 토픽에 제한되지 않고 CS 카테고리 전체 또는 직접 입력한 주제로 면접을 시작할 수 있게 하기 위함입니다.

## 🧪 테스트
- [x] `npm run build` 통과
- [x] 수동 테스트 준비 및 승인 완료

## 🤔 고민한 부분 (선택)
- `전체` 선택은 백엔드 계약에 맞춰 `topics: []`로 전송하고, 제출 시 빈 배열이 제거되지 않도록 처리했습니다.

## 📸 스크린샷 (선택)

## ✅ 체크리스트
- [ ] 코드 리뷰 요청 완료
- [x] 불필요한 코드/로그 제거
- [x] 문서 업데이트 (필요 시)

## 🔗 관련 이슈
- Relates to #23


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 업데이트 내역

* **문서**
  * 백엔드 및 프론트엔드 README 추가/대체: 프로젝트 개요, 기능, 기술 스택, 로컬 실행·테스트 안내(프론트는 한국어 문서화)

* **새로운 기능**
  * CS 과목별 커스텀 주제 입력 UI 추가(카테고리별 자유 텍스트 입력 및 동작)

* **개선**
  * 면접 설정 전송 로직 변경: CS 섹션 데이터 처리 방식 수정
  * 면접 요약의 CS 선택 수 표시 방식 개선(선택 수 집계 방식 업데이트)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->